### PR TITLE
change replaygain from gstreamer to bs1770gain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 sudo: false
 language: python
 python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python: 3.6
 addons:
   apt:
     packages:
+      - bs1770gain
       - liquidsoap
       - liquidsoap-plugin-icecast
       - liquidsoap-plugin-lame

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: trusty
 sudo: false
 language: python
 python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python: 3.6
 addons:
   apt:
     packages:
-      - bs1770gain
       - liquidsoap
       - liquidsoap-plugin-icecast
       - liquidsoap-plugin-lame

--- a/klangbecken_api.py
+++ b/klangbecken_api.py
@@ -78,10 +78,7 @@ class KlangbeckenAPI:
         output = subprocess.check_output(bs1770gain_cmd)
         bs1770gain = ElementTree.fromstring(output)
         # lu is in bs1770gain > album > track > integrated as an attribute
-        track_gain = bs1770gain.find('album') \
-                               .find('track') \
-                               .find('integrated') \
-                               .attrib['lu']
+        track_gain = bs1770gain.find('./album/track/integrated').attrib['lu']
         mutagenfile['track_gain'] = track_gain + ' db'
         mutagenfile.save()
 

--- a/klangbecken_api.py
+++ b/klangbecken_api.py
@@ -7,6 +7,7 @@ import subprocess
 from collections import Counter
 from io import open
 from os.path import join as pjoin
+from xml.etree import ElementTree
 
 import mutagen
 from mutagen.easyid3 import EasyID3
@@ -71,21 +72,16 @@ class KlangbeckenAPI:
         return pjoin(self.data_dir, path)
 
     def _replaygain_analysis(self, mutagenfile):
-        # 1. compute track_gain
-        gstreamer_cmd = [
-            "gst-launch-1.0", "-t",
-            "filesrc", "location="+mutagenfile.filename,
-            "!", "decodebin",
-            "!", "audioconvert",
-            "!", "audioresample",
-            "!", "rganalysis",
-            "!", "fakesink"
+        bs1770gain_cmd = [
+            "/usr/bin/bs1770gain", "--ebu", "--xml", mutagenfile.filename
         ]
-        output = str(subprocess.check_output(gstreamer_cmd))
-        search_str = 'replaygain track gain: '
-        start = output.find(search_str) + len(search_str)
-        track_gain = output[start:None].split('\\n')[0]
-        # 2. set TXXX tag
+        output = subprocess.check_output(bs1770gain_cmd)
+        bs1770gain = ElementTree.fromstring(output)
+        # lu is in bs1770gain > album > track > integrated as an attribute
+        track_gain = bs1770gain.find('album') \
+                               .find('track') \
+                               .find('integrated') \
+                               .attrib['lu']
         mutagenfile['track_gain'] = track_gain + ' db'
         mutagenfile.save()
 


### PR DESCRIPTION
This changes the replaygain analysis from using gstreamer to bs1770gain. I used the 'lu' field of bs1770gain's xml output. This fixes #4.

The output looks like this:
```xml
<bs1770gain>
  <album>
    <track total="1" number="1" file="01&#x5F;Birds&#x5F;n&#x5F;Bars&#x2E;mp3">
      <integrated lufs="-8.94" lu="-14.06" />
    </track>
    <summary total="1">
      <integrated lufs="-8.94" lu="-14.06" />
    </summary>
  </album>
</bs1770gain>
```