### PR TITLE
blacken code and clean up test-env install, introduce pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: local
+    hooks:
+      - id: black
+        name: black
+        language: system
+        entry: black
+        types: [python]
+      - id: isort
+        name: isort
+        language: system
+        entry: isort -y
+        types: [python]
+      - id: flake8
+        name: flake8
+        language: system
+        entry: flake8
+        types: [python]

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ before_install:
   - pip install -U pip
   - pip install codecov
 install:
-  - pip install  ".[test]" .
+  - pip install -r requirements-dev.txt
+  - pip install -e .
 script:
+  - pre-commit run -a
   - klangbecken init -d $KLANGBECKEN_DATA
   - coverage run --source=klangbecken -m unittest discover
   - flake8

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/radiorabe/klangbecken.svg?branch=master)](https://travis-ci.org/radiorabe/klangbecken)
 [![Coverage Status](https://codecov.io/gh/radiorabe/klangbecken/branch/master/graph/badge.svg)](https://codecov.io/gh/radiorabe/klangbecken)
+[![Codestyle Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 ## Description
 This repo contains two parts of the RaBe-Klangbecken infrastructure:
@@ -46,6 +47,7 @@ python3 -m venv venv && source venv/bin/activate
 * Python
   ```bash
   pip install -r requirements.txt
+  pip install -r requirements-dev.txt
   ```
 * Liquidsoap (on CentOS 7 you can also use our prebuilt [package](https://github.com/radiorabe/centos-rpm-liquidsoap))
   ```bash
@@ -98,11 +100,28 @@ tox -p auto
 python -m unittest discover
 ```
 
+#### Format code
+
+```bash
+black .
+```
+
 #### Check your style
+
 ```bash
 flake8
 ```
 
+#### Automate formatting using pre-commit
+
+After registering hooks with `init` pre-commit will abort commits if there are black, isort or flake8 changes to be made. If machine fixable (ie. black and isort) pre-commit usually applies those changes leaving you to stage them using `git add` before retrying your commit.
+```bash
+pre-commit init
+```
+You can also run black, isort and flake8 on all content without comitting:
+```bash
+pre-commit run -a
+```
 
 ### Automatically activate and deactivate virtualenvs when changing directories
 

--- a/klangbecken.py
+++ b/klangbecken.py
@@ -29,9 +29,7 @@ import datetime
 import fcntl
 import functools
 import json
-import jwt
 import os
-import pkg_resources
 import random
 import re
 import shutil
@@ -40,80 +38,81 @@ import sys
 import threading
 import uuid
 
+import jwt
 import mutagen
 import mutagen.easyid3
 import mutagen.flac
 import mutagen.mp3
 import mutagen.oggvorbis
-
-from werkzeug.exceptions import (HTTPException, UnprocessableEntity, NotFound,
-                                 Unauthorized)
+import pkg_resources
+from werkzeug.exceptions import (
+    HTTPException,
+    NotFound,
+    Unauthorized,
+    UnprocessableEntity,
+)
 from werkzeug.routing import Map, Rule
 from werkzeug.wrappers import Request, Response
 
-
 try:
-    __version__ = pkg_resources.get_distribution('klangbecken').version
-except pkg_resources.DistributionNotFound:   # pragma: no cover
-    __version__ = 'development version'
+    __version__ = pkg_resources.get_distribution("klangbecken").version
+except pkg_resources.DistributionNotFound:  # pragma: no cover
+    __version__ = "development version"
 
 
 ############
 # Settings #
 ############
-PLAYLISTS = ('music', 'classics', 'jingles')
+PLAYLISTS = ("music", "classics", "jingles")
 
 SUPPORTED_FILE_TYPES = {
-    '.mp3': mutagen.mp3.EasyMP3,
-    '.ogg': mutagen.oggvorbis.OggVorbis,
-    '.flac': mutagen.flac.FLAC,
+    ".mp3": mutagen.mp3.EasyMP3,
+    ".ogg": mutagen.oggvorbis.OggVorbis,
+    ".flac": mutagen.flac.FLAC,
 }
 
-ISO8601_RE = \
-   (
+ISO8601_RE = (
     # Date
-    r'(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T'
+    r"(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T"
     # Time (optionally with a fraction of a second)
-    r'(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?'
+    r"(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?"
     # Timezone information (Z for UTC or +/- offset from UTC)
-    r'(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?'
-   )
+    r"(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?"
+)
 
 # Attention: The order of metadata keys is used when writing CSV log files.
 # Do not reorder or delete metadata keys. Renaming or addition at the end is
 # okay.
 ALLOWED_METADATA = {
-    'id': (str, r'^[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}$'),
-    'ext': (str, lambda ext: ext in SUPPORTED_FILE_TYPES.keys()),
-    'playlist': (str, lambda pl: pl in PLAYLISTS),
-    'original_filename': str,
-    'import_timestamp': ISO8601_RE,
-    'weight': (int, lambda c: c >= 0),
-
-    'artist': str,
-    'title': str,
-    'album': str,
-    'length': (float, lambda n: n >= 0.0),
-
-    'track_gain': (str, r'^[+-]?[0-9]*(\.[0-9]*) dB$'),
-    'cue_in':  (float, lambda n: n >= 0.0),
-    'cue_out': (float, lambda n: n >= 0.0),
-
-    'play_count': (int, lambda n: n >= 0),
-    'last_play': (str, r'^(^$)|(^{}$)'.format(ISO8601_RE)),
+    "id": (str, r"^[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}$"),
+    "ext": (str, lambda ext: ext in SUPPORTED_FILE_TYPES.keys()),
+    "playlist": (str, lambda pl: pl in PLAYLISTS),
+    "original_filename": str,
+    "import_timestamp": ISO8601_RE,
+    "weight": (int, lambda c: c >= 0),
+    "artist": str,
+    "title": str,
+    "album": str,
+    "length": (float, lambda n: n >= 0.0),
+    "track_gain": (str, r"^[+-]?[0-9]*(\.[0-9]*) dB$"),
+    "cue_in": (float, lambda n: n >= 0.0),
+    "cue_out": (float, lambda n: n >= 0.0),
+    "play_count": (int, lambda n: n >= 0),
+    "last_play": (str, r"^(^$)|(^{0}$)".format(ISO8601_RE)),
 }
 
-UPDATE_KEYS = 'artist title album weight'.split()
-TAG_KEYS = ('artist title album cue_in cue_out track_gain '
-            'original_filename import_timestamp').split()
+UPDATE_KEYS = "artist title album weight".split()
+TAG_KEYS = (
+    "artist title album cue_in cue_out track_gain " "original_filename import_timestamp"
+).split()
 
 
 ####################
 # Action-"Classes" #
 ####################
-FileAddition = collections.namedtuple('FileAddition', ('file'))
-MetadataChange = collections.namedtuple('MetadataChange', ('key', 'value'))
-FileDeletion = collections.namedtuple('FileDeletion', ())
+FileAddition = collections.namedtuple("FileAddition", ("file"))
+MetadataChange = collections.namedtuple("MetadataChange", ("key", "value"))
+FileDeletion = collections.namedtuple("FileDeletion", ())
 
 
 #############
@@ -121,25 +120,24 @@ FileDeletion = collections.namedtuple('FileDeletion', ())
 #############
 def raw_file_analyzer(playlist, fileId, ext, file_):
     if not file_:
-        raise UnprocessableEntity('No File found')
+        raise UnprocessableEntity("No File found")
 
     if ext not in SUPPORTED_FILE_TYPES.keys():
-        raise UnprocessableEntity(f'Unsupported file extension: {ext}')
+        raise UnprocessableEntity(f"Unsupported file extension: {ext}")
 
     # Be compatible with werkzeug.datastructures.FileStorage and plain files
-    filename = file_.filename if hasattr(file_, 'filename') else file_.name
+    filename = file_.filename if hasattr(file_, "filename") else file_.name
 
     return [
         FileAddition(file_),
-        MetadataChange('id', fileId),
-        MetadataChange('ext', ext),
-        MetadataChange('playlist', playlist),
-        MetadataChange('original_filename', filename),
-        MetadataChange('import_timestamp',
-                       datetime.datetime.now().isoformat()),
-        MetadataChange('weight', 1),
-        MetadataChange('play_count', 0),
-        MetadataChange('last_play', ''),
+        MetadataChange("id", fileId),
+        MetadataChange("ext", ext),
+        MetadataChange("playlist", playlist),
+        MetadataChange("original_filename", filename),
+        MetadataChange("import_timestamp", datetime.datetime.now().isoformat()),
+        MetadataChange("weight", 1),
+        MetadataChange("play_count", 0),
+        MetadataChange("last_play", ""),
     ]
 
 
@@ -149,21 +147,22 @@ def mutagen_tag_analyzer(playlist, fileId, ext, file_):
         try:
             mutagenfile = MutagenFileType(file_)
         except mutagen.MutagenError:
-            raise UnprocessableEntity('Unsupported file type: ' +
-                                      'Cannot read metadata.')
+            raise UnprocessableEntity(
+                "Unsupported file type: " + "Cannot read metadata."
+            )
         changes = [
-            MetadataChange('artist', mutagenfile.get('artist', [''])[0]),
-            MetadataChange('title', mutagenfile.get('title', [''])[0]),
-            MetadataChange('album', mutagenfile.get('album', [''])[0]),
-            MetadataChange('length', mutagenfile.info.length),
+            MetadataChange("artist", mutagenfile.get("artist", [""])[0]),
+            MetadataChange("title", mutagenfile.get("title", [""])[0]),
+            MetadataChange("album", mutagenfile.get("album", [""])[0]),
+            MetadataChange("length", mutagenfile.info.length),
         ]
     # Seek back to the start of the file for whoever comes next
     file_.seek(0)
     return changes
 
 
-silence_re = re.compile(r'silencedetect.*silence_(start|end):\s*(\S*)')
-trackgain_re = re.compile(r'replaygain.*track_gain = (\S* dB)')
+silence_re = re.compile(r"silencedetect.*silence_(start|end):\s*(\S*)")
+trackgain_re = re.compile(r"replaygain.*track_gain = (\S* dB)")
 
 
 def ffmpeg_audio_analyzer(playlist, fileId, ext, file_):
@@ -171,12 +170,13 @@ def ffmpeg_audio_analyzer(playlist, fileId, ext, file_):
     replaygain,apad=pad_len=100000,silencedetect=d=0.01 -f null -""".split()
 
     try:
-        raw_output = subprocess.check_output(command, stdin=file_,
-                                             stderr=subprocess.STDOUT)
+        raw_output = subprocess.check_output(
+            command, stdin=file_, stderr=subprocess.STDOUT
+        )
         # Non-ASCII characters can safely be ignored
-        output = str(raw_output, 'ascii', errors='ignore')
+        output = str(raw_output, "ascii", errors="ignore")
     except subprocess.CalledProcessError:
-        raise UnprocessableEntity('Cannot process audio data')
+        raise UnprocessableEntity("Cannot process audio data")
 
     gain = trackgain_re.search(output).groups()[0]
     silence_times = re.findall(silence_re, output)
@@ -184,29 +184,30 @@ def ffmpeg_audio_analyzer(playlist, fileId, ext, file_):
 
     # Last 'start' time is cue_out
     reversed_times = reversed(silence_times)
-    cue_out = next((t[1] for t in reversed_times
-                    if t[0] == 'start'))                # pragma: no cover
+    cue_out = next(
+        (t[1] for t in reversed_times if t[0] == "start")
+    )  # pragma: no cover
 
     if -0.05 < cue_out < 0.0:  # pragma: no cover
         cue_out = 0.0
 
     # From remaining times, first 'end' time is cue_in, otherwise 0.0
     remaining_times = reversed(list(reversed_times))
-    cue_in = next((t[1] for t in remaining_times if t[0] == 'end'), 0.0)
+    cue_in = next((t[1] for t in remaining_times if t[0] == "end"), 0.0)
 
     # Fix small negative values for cue_in
     if -0.05 < cue_in < 0.0:  # pragma: no cover
         cue_in = 0.0
 
     # Fix clearly too large cue_in values
-    if cue_in > (cue_out * .75):
+    if cue_in > (cue_out * 0.75):
         cue_in = 0.0
 
     file_.seek(0)
     return [
-        MetadataChange('track_gain', gain),
-        MetadataChange('cue_in', cue_in),
-        MetadataChange('cue_out', cue_out),
+        MetadataChange("track_gain", gain),
+        MetadataChange("cue_in", cue_in),
+        MetadataChange("cue_out", cue_out),
     ]
 
 
@@ -220,31 +221,31 @@ DEFAULT_UPLOAD_ANALYZERS = [
 def update_data_analyzer(playlist, fileId, ext, data):
     changes = []
     if not isinstance(data, dict):
-        raise UnprocessableEntity('Invalid data format: ' +
-                                  'associative array expected')
+        raise UnprocessableEntity(
+            "Invalid data format: " + "associative array expected"
+        )
     for key, value in data.items():
         if key not in UPDATE_KEYS:
-            raise UnprocessableEntity('Invalid data format: ' +
-                                      f'Key not allowed: {key}')
+            raise UnprocessableEntity(
+                "Invalid data format: " + f"Key not allowed: {key}"
+            )
         changes.append(MetadataChange(key, value))
     return changes
 
 
-DEFAULT_UPDATE_ANALYZERS = [
-    update_data_analyzer
-]
+DEFAULT_UPDATE_ANALYZERS = [update_data_analyzer]
 
 
 ##############
 # Processors #
 ##############
-def check_processor(data_dir, playlist, fileId, ext, changes):
+def check_processor(data_dir, playlist, fileId, ext, changes):  # noqa: C901
     for change in changes:
         if isinstance(change, MetadataChange):
             key, val = change
 
             if key not in ALLOWED_METADATA.keys():
-                raise UnprocessableEntity(f'Invalid metadata key: {key}')
+                raise UnprocessableEntity(f"Invalid metadata key: {key}")
 
             checks = ALLOWED_METADATA[key]
             if not isinstance(checks, (list, tuple)):
@@ -255,8 +256,8 @@ def check_processor(data_dir, playlist, fileId, ext, changes):
                     if not isinstance(val, check):
                         raise UnprocessableEntity(
                             f'Invalid data format for "{key}": Type error '
-                            f'(expected {check.__name__}, '
-                            f'got {type(val).__name__}).'
+                            f"(expected {check.__name__}, "
+                            f"got {type(val).__name__})."
                         )
                 elif callable(check):
                     if not check(val):
@@ -275,30 +276,37 @@ def check_processor(data_dir, playlist, fileId, ext, changes):
         elif isinstance(change, (FileAddition, FileDeletion)):
             pass
         else:
-            raise ValueError('Invalid action class')
+            raise ValueError("Invalid action class")
 
 
 def filter_duplicates_processor(data_dir, playlist, file_id, ext, changes):
-    with locked_open(os.path.join(data_dir, 'index.json')) as f:
+    with locked_open(os.path.join(data_dir, "index.json")) as f:
         data = json.load(f)
 
     addition = [c for c in changes if isinstance(c, FileAddition)]
     if addition:
         changes = [c for c in changes if isinstance(c, MetadataChange)]
 
-        filename = [c.value for c in changes
-                    if c.key == 'original_filename'][0]
-        title = [c.value for c in changes if c.key == 'title'][0]
-        artist = [c.value for c in changes if c.key == 'artist'][0]
+        filename = [c.value for c in changes if c.key == "original_filename"][0]
+        title = [c.value for c in changes if c.key == "title"][0]
+        artist = [c.value for c in changes if c.key == "artist"][0]
 
         for entry in data.values():
-            if (entry['original_filename'] == filename and
-                    entry['artist'] == artist and
-                    entry['title'] == title and
-                    entry['playlist'] == playlist):
-                raise UnprocessableEntity('Duplicate file entry:\n' +
-                                          artist + ' - ' + title +
-                                          ' (' + filename + ')')
+            if (
+                entry["original_filename"] == filename
+                and entry["artist"] == artist
+                and entry["title"] == title
+                and entry["playlist"] == playlist
+            ):
+                raise UnprocessableEntity(
+                    "Duplicate file entry:\n"
+                    + artist
+                    + " - "
+                    + title
+                    + " ("
+                    + filename
+                    + ")"
+                )
 
 
 def raw_file_processor(data_dir, playlist, fileId, ext, changes):
@@ -309,7 +317,7 @@ def raw_file_processor(data_dir, playlist, fileId, ext, changes):
             if isinstance(file_, str):
                 shutil.copy(file_, path)
             else:
-                with open(path, 'wb') as dest:
+                with open(path, "wb") as dest:
                     shutil.copyfileobj(file_, dest)
         elif isinstance(change, FileDeletion):
             if not os.path.isfile(path):
@@ -319,16 +327,16 @@ def raw_file_processor(data_dir, playlist, fileId, ext, changes):
             if not os.path.isfile(path):
                 raise NotFound()
         else:
-            raise ValueError('Invalid action class')
+            raise ValueError("Invalid action class")
 
 
 def index_processor(data_dir, playlist, fileId, ext, changes, json_opts={}):
-    with locked_open(os.path.join(data_dir, 'index.json')) as f:
+    with locked_open(os.path.join(data_dir, "index.json")) as f:
         data = json.load(f)
         for change in changes:
             if isinstance(change, FileAddition):
                 if fileId in data:
-                    raise UnprocessableEntity('Duplicate file ID: ' + fileId)
+                    raise UnprocessableEntity("Duplicate file ID: " + fileId)
                 data[fileId] = {}
             elif isinstance(change, FileDeletion):
                 if fileId not in data:
@@ -340,20 +348,19 @@ def index_processor(data_dir, playlist, fileId, ext, changes, json_opts={}):
                     raise NotFound()
                 data[fileId][key] = value
             else:
-                raise ValueError('Change not recognized')
+                raise ValueError("Change not recognized")
         f.seek(0)
         f.truncate()
         json.dump(data, f, **json_opts)
 
 
-mutagen.easyid3.EasyID3.RegisterTXXXKey(key='cue_in', desc='CUE_IN')
-mutagen.easyid3.EasyID3.RegisterTXXXKey(key='cue_out', desc='CUE_OUT')
-mutagen.easyid3.EasyID3.RegisterTXXXKey(key='track_gain',
-                                        desc='REPLAYGAIN_TRACK_GAIN')
-mutagen.easyid3.EasyID3.RegisterTXXXKey(key='original_filename',
-                                        desc='ORIGINAL_FILENAME')
-mutagen.easyid3.EasyID3.RegisterTXXXKey(key='import_timestamp',
-                                        desc='IMPORT_TIMESTAMP')
+mutagen.easyid3.EasyID3.RegisterTXXXKey(key="cue_in", desc="CUE_IN")
+mutagen.easyid3.EasyID3.RegisterTXXXKey(key="cue_out", desc="CUE_OUT")
+mutagen.easyid3.EasyID3.RegisterTXXXKey(key="track_gain", desc="REPLAYGAIN_TRACK_GAIN")
+mutagen.easyid3.EasyID3.RegisterTXXXKey(
+    key="original_filename", desc="ORIGINAL_FILENAME"
+)
+mutagen.easyid3.EasyID3.RegisterTXXXKey(key="import_timestamp", desc="IMPORT_TIMESTAMP")
 
 
 def file_tag_processor(data_dir, playlist, fileId, ext, changes):
@@ -375,21 +382,20 @@ def file_tag_processor(data_dir, playlist, fileId, ext, changes):
 
 
 def playlist_processor(data_dir, playlist, fileId, ext, changes):
-    playlist_path = os.path.join(data_dir, playlist + '.m3u')
+    playlist_path = os.path.join(data_dir, playlist + ".m3u")
     for change in changes:
         if isinstance(change, FileDeletion):
             with locked_open(playlist_path) as f:
-                lines = (s.strip() for s in f.readlines() if s != '\n')
+                lines = (s.strip() for s in f.readlines() if s != "\n")
                 f.seek(0)
                 f.truncate()
                 for line in lines:
                     if not line.endswith(os.path.join(playlist, fileId + ext)):
                         print(line, file=f)
-        elif isinstance(change, MetadataChange) and change.key == 'weight':
+        elif isinstance(change, MetadataChange) and change.key == "weight":
             with locked_open(playlist_path) as f:
-                lines = (s.strip() for s in f.readlines() if s != '\n')
-                lines = [s for s in lines
-                         if s and not s.endswith(fileId + ext)]
+                lines = (s.strip() for s in f.readlines() if s != "\n")
+                lines = [s for s in lines if s and not s.endswith(fileId + ext)]
 
                 weight = change.value
                 lines.extend([os.path.join(playlist, fileId + ext)] * weight)
@@ -401,34 +407,33 @@ def playlist_processor(data_dir, playlist, fileId, ext, changes):
 
 
 DEFAULT_PROCESSORS = [
-    check_processor,      # type and contract check changes
+    check_processor,  # type and contract check changes
     filter_duplicates_processor,
-    raw_file_processor,   # save file
-    file_tag_processor,   # update tags
-    playlist_processor,   # update playlist file
-    index_processor,      # commit file to index at last
+    raw_file_processor,  # save file
+    file_tag_processor,  # update tags
+    playlist_processor,  # update playlist file
+    index_processor,  # commit file to index at last
 ]
 
 
 def playnext_processor(data_dir, data):
     if not isinstance(data, dict):
-        raise UnprocessableEntity('Invalid data format: '
-                                  'associative array expected')
-    if 'file' not in data:
-        raise UnprocessableEntity('Invalid data format: '
-                                  'Key "file" not found')
+        raise UnprocessableEntity("Invalid data format: " "associative array expected")
+    if "file" not in data:
+        raise UnprocessableEntity("Invalid data format: " 'Key "file" not found')
 
-    filename = data['file']
-    filename_re = r'^({})/([^/.]+)({})$' \
-        .format('|'.join(PLAYLISTS), '|'.join(SUPPORTED_FILE_TYPES.keys()))
+    filename = data["file"]
+    filename_re = r"^({0})/([^/.]+)({1})$".format(
+        "|".join(PLAYLISTS), "|".join(SUPPORTED_FILE_TYPES.keys())
+    )
     if not re.match(filename_re, filename):
-        raise UnprocessableEntity('Invalid file path format')
+        raise UnprocessableEntity("Invalid file path format")
 
     path = os.path.join(data_dir, filename)
     if not os.path.isfile(path):
         raise NotFound()
 
-    with locked_open(os.path.join(data_dir, 'prio.m3u')) as f:
+    with locked_open(os.path.join(data_dir, "prio.m3u")) as f:
         f.seek(0)
         f.truncate()
         print(filename, file=f)
@@ -441,10 +446,10 @@ _mutagenLock = threading.Lock()
 
 
 @contextlib.contextmanager
-def locked_open(path, mode='r+'):
+def locked_open(path, mode="r+"):
     if path not in _locks:
         _locks[path] = threading.Lock()
-    with _locks[path]:   # Prevent more than one thread accessing the file
+    with _locks[path]:  # Prevent more than one thread accessing the file
         with open(path, mode) as f:
             # Prevent more than one process accessing the file (voluntarily)
             fcntl.lockf(f, fcntl.LOCK_EX)
@@ -458,14 +463,15 @@ def locked_open(path, mode='r+'):
 # HTTP API #
 ############
 class KlangbeckenAPI:
-
-    def __init__(self,
-                 data_dir,
-                 secret,
-                 upload_analyzers=DEFAULT_UPLOAD_ANALYZERS,
-                 update_analyzers=DEFAULT_UPDATE_ANALYZERS,
-                 processors=DEFAULT_PROCESSORS,
-                 disable_auth=False):
+    def __init__(
+        self,
+        data_dir,
+        secret,
+        upload_analyzers=DEFAULT_UPLOAD_ANALYZERS,
+        update_analyzers=DEFAULT_UPDATE_ANALYZERS,
+        processors=DEFAULT_PROCESSORS,
+        disable_auth=False,
+    ):
         self.data_dir = data_dir
         self.secret = secret
         self.upload_analyzers = upload_analyzers
@@ -473,19 +479,24 @@ class KlangbeckenAPI:
         self.processors = processors
         self.do_auth = not disable_auth
 
-        playlist_url = '/<any(' + ', '.join(PLAYLISTS) + '):playlist>/'
-        file_url = playlist_url + '<uuid:fileId><any(' + \
-            ', '.join(SUPPORTED_FILE_TYPES.keys()) + '):ext>'
+        playlist_url = "/<any(" + ", ".join(PLAYLISTS) + "):playlist>/"
+        file_url = (
+            playlist_url
+            + "<uuid:fileId><any("
+            + ", ".join(SUPPORTED_FILE_TYPES.keys())
+            + "):ext>"
+        )
 
-        self.url_map = Map(rules=(
-            Rule('/auth/login/', methods=('GET', 'POST'), endpoint='login'),
-            Rule('/auth/renew/', methods=('POST',), endpoint='renew'),
-
-            Rule(playlist_url, methods=('POST',), endpoint='upload'),
-            Rule(file_url, methods=('PUT',), endpoint='update'),
-            Rule(file_url, methods=('DELETE',), endpoint='delete'),
-            Rule('/playnext/', methods=('POST',), endpoint='play_next')
-        ))
+        self.url_map = Map(
+            rules=(
+                Rule("/auth/login/", methods=("GET", "POST"), endpoint="login"),
+                Rule("/auth/renew/", methods=("POST",), endpoint="renew"),
+                Rule(playlist_url, methods=("POST",), endpoint="upload"),
+                Rule(file_url, methods=("PUT",), endpoint="update"),
+                Rule(file_url, methods=("DELETE",), endpoint="delete"),
+                Rule("/playnext/", methods=("POST",), endpoint="play_next"),
+            )
+        )
 
     def __call__(self, environ, start_response):
         try:
@@ -494,29 +505,32 @@ class KlangbeckenAPI:
             endpoint, values = adapter.match()
 
             # Check authorization
-            if self.do_auth and endpoint not in ('login', 'renew'):
-                if 'Authorization' not in request.headers:
-                    raise Unauthorized('No authorization header supplied')
+            if self.do_auth and endpoint not in ("login", "renew"):
+                if "Authorization" not in request.headers:
+                    raise Unauthorized("No authorization header supplied")
 
-                auth = request.headers['Authorization']
-                if not auth.startswith('Bearer '):
-                    raise Unauthorized('Invalid authorization header')
+                auth = request.headers["Authorization"]
+                if not auth.startswith("Bearer "):
+                    raise Unauthorized("Invalid authorization header")
 
-                token = auth[len('Bearer '):]
+                token = auth[len("Bearer ") :]
                 try:
-                    jwt.decode(token, self.secret, algorithms=['HS256'],
-                               options={'require_exp': True,
-                                        'require_iat': True})
+                    jwt.decode(
+                        token,
+                        self.secret,
+                        algorithms=["HS256"],
+                        options={"require_exp": True, "require_iat": True},
+                    )
                 except jwt.InvalidTokenError:
-                    raise Unauthorized('Invalid token')
+                    raise Unauthorized("Invalid token")
 
             # Dispatch request
-            response = getattr(self, 'on_' + endpoint)(request, **values)
+            response = getattr(self, "on_" + endpoint)(request, **values)
         except HTTPException as e:
-            response = JSONResponse({'code': e.code,
-                                     'name': e.name,
-                                     'description': e.description},
-                                    status=e.code)
+            response = JSONResponse(
+                {"code": e.code, "name": e.name, "description": e.description},
+                status=e.code,
+            )
         return response(environ, start_response)
 
     def on_login(self, request):
@@ -525,50 +539,54 @@ class KlangbeckenAPI:
 
         user = request.remote_user
         now = datetime.datetime.utcnow()
-        claims = {
-            'user': user,
-            'iat': now,
-            'exp': now + datetime.timedelta(minutes=15)
-        }
-        token = str(jwt.encode(claims, self.secret, algorithm='HS256'),
-                    'ascii')
+        claims = {"user": user, "iat": now, "exp": now + datetime.timedelta(minutes=15)}
+        token = str(jwt.encode(claims, self.secret, algorithm="HS256"), "ascii")
 
-        return JSONResponse({'token': token})
+        return JSONResponse({"token": token})
 
-    def on_renew(self, request):
+    def on_renew(self, request):  # noqa: C901
         try:
-            data = json.loads(str(request.data, 'utf-8'))
+            data = json.loads(str(request.data, "utf-8"))
         except (UnicodeDecodeError, TypeError):
-            raise UnprocessableEntity('Cannot parse POST request: '
-                                      'invalid UTF-8 data')
+            raise UnprocessableEntity(
+                "Cannot parse POST request: " "invalid UTF-8 data"
+            )
         except ValueError:
-            raise UnprocessableEntity('Cannot parse POST request: '
-                                      'invalid JSON')
+            raise UnprocessableEntity("Cannot parse POST request: " "invalid JSON")
         if not isinstance(data, dict):
-            raise UnprocessableEntity('Invalid data format: '
-                                      'associative array expected')
-        if 'token' not in data:
-            raise UnprocessableEntity('Invalid data format: '
-                                      'Key "token" not found')
+            raise UnprocessableEntity(
+                "Invalid data format: " "associative array expected"
+            )
+        if "token" not in data:
+            raise UnprocessableEntity("Invalid data format: " 'Key "token" not found')
 
-        token = data['token']
+        token = data["token"]
 
         now = datetime.datetime.utcnow()
         try:
             # Valid tokens can always be renewed withing their short lifetime,
             # independent of the issuing date
-            claims = jwt.decode(token, self.secret, algorithms=['HS256'],
-                                options={'require_exp': True,
-                                         'require_iat': True})
+            claims = jwt.decode(
+                token,
+                self.secret,
+                algorithms=["HS256"],
+                options={"require_exp": True, "require_iat": True},
+            )
         except jwt.ExpiredSignatureError:
             try:
                 # Expired tokens can be renewed for at most one week after the
                 # first issuing date
-                claims = jwt.decode(token, self.secret, algorithms=['HS256'],
-                                    options={'require_exp': True,
-                                             'require_iat': True,
-                                             'verify_exp': False})
-                issued_at = datetime.datetime.utcfromtimestamp(claims['iat'])
+                claims = jwt.decode(
+                    token,
+                    self.secret,
+                    algorithms=["HS256"],
+                    options={
+                        "require_exp": True,
+                        "require_iat": True,
+                        "verify_exp": False,
+                    },
+                )
+                issued_at = datetime.datetime.utcfromtimestamp(claims["iat"])
                 if issued_at + datetime.timedelta(days=7) < now:
                     raise Unauthorized()
             except jwt.InvalidTokenError:
@@ -576,22 +594,21 @@ class KlangbeckenAPI:
         except jwt.InvalidTokenError:
             raise Unauthorized()
 
-        claims['exp'] = now + datetime.timedelta(minutes=15)
+        claims["exp"] = now + datetime.timedelta(minutes=15)
 
-        token = str(jwt.encode(claims, self.secret, algorithm='HS256'),
-                    'ascii')
+        token = str(jwt.encode(claims, self.secret, algorithm="HS256"), "ascii")
 
-        return JSONResponse({'token': token})
+        return JSONResponse({"token": token})
 
     def on_upload(self, request, playlist):
-        if 'file' not in request.files:
+        if "file" not in request.files:
             raise UnprocessableEntity("No attribute named 'file' found.")
 
         try:
-            uploadFile = request.files['file']
+            uploadFile = request.files["file"]
 
             ext = os.path.splitext(uploadFile.filename)[1].lower()
-            fileId = str(uuid.uuid4())   # Generate new file id
+            fileId = str(uuid.uuid4())  # Generate new file id
 
             actions = []
             for analyzer in self.upload_analyzers:
@@ -614,21 +631,19 @@ class KlangbeckenAPI:
 
         actions = []
         try:
-            data = json.loads(str(request.data, 'utf-8'))
+            data = json.loads(str(request.data, "utf-8"))
             for analyzer in self.update_analyzers:
                 actions += analyzer(playlist, fileId, ext, data)
 
         except (UnicodeDecodeError, TypeError):
-            raise UnprocessableEntity('Cannot parse PUT request: '
-                                      'invalid UTF-8 data')
+            raise UnprocessableEntity("Cannot parse PUT request: " "invalid UTF-8 data")
         except ValueError:
-            raise UnprocessableEntity('Cannot parse PUT request: '
-                                      'invalid JSON')
+            raise UnprocessableEntity("Cannot parse PUT request: " "invalid JSON")
 
         for processor in self.processors:
             processor(self.data_dir, playlist, fileId, ext, actions)
 
-        return JSONResponse({'status': 'OK'})
+        return JSONResponse({"status": "OK"})
 
     def on_delete(self, request, playlist, fileId, ext):
         fileId = str(fileId)
@@ -637,42 +652,40 @@ class KlangbeckenAPI:
         for processor in self.processors:
             processor(self.data_dir, playlist, fileId, ext, change)
 
-        return JSONResponse({'status': 'OK'})
+        return JSONResponse({"status": "OK"})
 
     def on_play_next(self, request):
         try:
-            data = json.loads(str(request.data, 'utf-8'))
+            data = json.loads(str(request.data, "utf-8"))
             playnext_processor(self.data_dir, data)
 
         except (UnicodeDecodeError, TypeError):
-            raise UnprocessableEntity('Cannot parse PUT request: '
-                                      'invalid UTF-8 data')
+            raise UnprocessableEntity("Cannot parse PUT request: " "invalid UTF-8 data")
         except ValueError:
-            raise UnprocessableEntity('Cannot parse PUT request: '
-                                      'invalid JSON')
+            raise UnprocessableEntity("Cannot parse PUT request: " "invalid JSON")
 
-        return JSONResponse({'status': 'OK'})
+        return JSONResponse({"status": "OK"})
 
 
 class JSONResponse(Response):
-    """
-    JSON response helper
-    """
+    """JSON response helper creates JSON responses."""
+
     def __init__(self, data, status=200, **json_opts):
-        super(JSONResponse, self).__init__(json.dumps(data, **json_opts),
-                                           status=status, mimetype='text/json')
+        super(JSONResponse, self).__init__(
+            json.dumps(data, **json_opts), status=status, mimetype="text/json"
+        )
 
 
 class JSONSerializer:
     @staticmethod
     def dumps(obj):
         # UTF-8 encoding is default in Python 3+
-        return json.dumps(obj).encode('utf-8')
+        return json.dumps(obj).encode("utf-8")
 
     @staticmethod
     def loads(serialized):
         # UTF-8 encoding is default in Python 3+
-        return json.loads(str(serialized, 'utf-8'))
+        return json.loads(str(serialized, "utf-8"))
 
 
 ###########################
@@ -697,52 +710,54 @@ class StandaloneWebApplication:
         _check_data_dir(data_dir)
 
         # Only add ffmpeg_audio_analyzer to analyzers if binary is present
-        upload_analyzers = [
-          raw_file_analyzer,
-          mutagen_tag_analyzer,
-        ]
+        upload_analyzers = [raw_file_analyzer, mutagen_tag_analyzer]
         try:
-            subprocess.check_output('ffmpeg -version'.split())
+            subprocess.check_output("ffmpeg -version".split())
             upload_analyzers.append(ffmpeg_audio_analyzer)
         except (OSError, subprocess.CalledProcessError):  # pragma: no cover
-            print('WARNING: ffmpeg binary not found. '
-                  'No audio analysis is performed.', file=sys.stderr)
+            print(
+                "WARNING: ffmpeg binary not found. " "No audio analysis is performed.",
+                file=sys.stderr,
+            )
 
         # Slightly modify processors, such that index.json is pretty printed
         processors = [
             check_processor,
             filter_duplicates_processor,
             raw_file_processor,
-            functools.partial(index_processor,
-                              json_opts={'indent': 2, 'sort_keys': True}),
+            functools.partial(
+                index_processor, json_opts={"indent": 2, "sort_keys": True}
+            ),
             file_tag_processor,
             playlist_processor,
         ]
 
         # Create customized KlangbeckenAPI application
-        api = KlangbeckenAPI(data_dir, secret,
-                             upload_analyzers=upload_analyzers,
-                             processors=processors)
+        api = KlangbeckenAPI(
+            data_dir, secret, upload_analyzers=upload_analyzers, processors=processors
+        )
 
         # Return 404 Not Found by default
         app = NotFound()
         # Serve static files from the data directory
-        app = SharedDataMiddleware(app, {'/data': data_dir})
+        app = SharedDataMiddleware(app, {"/data": data_dir})
         # Relay requests to /api to the KlangbeckenAPI instance
-        app = DispatcherMiddleware(app, {'/api': api})
+        app = DispatcherMiddleware(app, {"/api": api})
 
         self.app = app
 
     def __call__(self, environ, start_response):
         # Insert dummy user for authentication
         # (normally done externally)
-        environ['REMOTE_USER'] = 'dummyuser'
+        environ["REMOTE_USER"] = "dummyuser"
 
         # Be nice
-        if environ['PATH_INFO'] == '/':
-            msg = b'Welcome to the Klangbecken API!\n'
-            start_response('200 OK', [('Content-Type', 'text/plain'),
-                                      ('Content-Length', str(len(msg)))])
+        if environ["PATH_INFO"] == "/":
+            msg = b"Welcome to the Klangbecken API!\n"
+            start_response(
+                "200 OK",
+                [("Content-Type", "text/plain"), ("Content-Length", str(len(msg)))],
+            )
             return [msg]
 
         return self.app(environ, start_response)
@@ -752,55 +767,52 @@ class StandaloneWebApplication:
 # Helpers #
 ###########
 def _check_data_dir(data_dir, create=False):
-    """
-    Create local data directory structure for testing and development
-    """
-    for path in [data_dir, os.path.join(data_dir, 'log')] + \
-            [os.path.join(data_dir, playlist) for playlist in PLAYLISTS]:
+    """Create local data directory structure for testing and development."""
+    for path in [data_dir, os.path.join(data_dir, "log")] + [
+        os.path.join(data_dir, playlist) for playlist in PLAYLISTS
+    ]:
         if not os.path.isdir(path):
             if create:
                 os.mkdir(path)
             else:
                 raise Exception(f"Directory '{path}' does not exist")
-    for path in [os.path.join(data_dir, d + '.m3u') for d in
-                 PLAYLISTS + ('prio',)]:
+    for path in [os.path.join(data_dir, d + ".m3u") for d in PLAYLISTS + ("prio",)]:
         if not os.path.isfile(path):
             if create:
-                with open(path, 'a'):
+                with open(path, "a"):
                     pass
             else:
                 raise Exception(f"Playlist '{path}'' does not exist")
-    path = os.path.join(data_dir, 'index.json')
+    path = os.path.join(data_dir, "index.json")
     if not os.path.isfile(path):
         if create:
-            with open(path, 'w') as f:
-                f.write('{}')
+            with open(path, "w") as f:
+                f.write("{}")
         else:
             raise Exception('File "index.json" does not exist')
 
 
 def _analyze_one_file(data_dir, playlist, filename, use_mtime=True):
     if not os.path.exists(filename):
-        raise UnprocessableEntity('File not found: ' + filename)
+        raise UnprocessableEntity("File not found: " + filename)
 
     ext = os.path.splitext(filename)[1].lower()
     if ext not in SUPPORTED_FILE_TYPES.keys():
-        raise UnprocessableEntity('File extension not supported: ' + ext)
+        raise UnprocessableEntity("File extension not supported: " + ext)
 
-    with open(filename, 'rb') as importFile:
+    with open(filename, "rb") as importFile:
         fileId = str(uuid.uuid4())
         actions = []
         for analyzer in DEFAULT_UPLOAD_ANALYZERS:
             actions += analyzer(playlist, fileId, ext, importFile)
 
-        actions.append(MetadataChange('original_filename',
-                                      os.path.basename(filename)))
+        actions.append(MetadataChange("original_filename", os.path.basename(filename)))
 
         if use_mtime:
             mtime = os.stat(filename).st_mtime
             mtime = datetime.datetime.fromtimestamp(mtime)
             mtime = mtime.isoformat()
-            actions.append(MetadataChange('import_timestamp', mtime))
+            actions.append(MetadataChange("import_timestamp", mtime))
 
         actions[0] = FileAddition(filename)
     return (filename, fileId, ext, actions)
@@ -812,39 +824,40 @@ def _analyze_one_file(data_dir, playlist, filename, use_mtime=True):
 def init_cmd(data_dir):
     if os.path.exists(data_dir):
         if os.path.isdir(data_dir) and len(os.listdir(data_dir)) != 0:
-            print(f'ERROR: Data directory {data_dir} exists but is not empty.')
+            print(f"ERROR: Data directory {data_dir} exists but is not empty.")
             exit(1)
     else:
         os.mkdir(data_dir)
     _check_data_dir(data_dir, create=True)
 
 
-def serve_cmd(data_dir, address='localhost', port=5000, dev_mode=False):
+def serve_cmd(data_dir, address="localhost", port=5000, dev_mode=False):
     # Run locally in stand-alone development mode
     from werkzeug.serving import run_simple
 
-    app = StandaloneWebApplication(data_dir, 'no secret')
+    app = StandaloneWebApplication(data_dir, "no secret")
 
-    run_simple(address, port, app, threaded=True,
-               use_reloader=dev_mode, use_debugger=dev_mode)
+    run_simple(
+        address, port, app, threaded=True, use_reloader=dev_mode, use_debugger=dev_mode
+    )
 
 
-def import_cmd(data_dir, playlist, files, yes, meta=None, use_mtime=True,
-               dev_mode=False):
-    """
-    Entry point for import script
-    """
+def import_cmd(  # noqa: C901
+    data_dir, playlist, files, yes, meta=None, use_mtime=True, dev_mode=False
+):
+    """Entry point for import script."""
+
     def err(*args):
         print(*args, file=sys.stderr)
 
     try:
         _check_data_dir(data_dir)
     except Exception as e:
-        err('ERROR: Problem with data directory.', str(e))
+        err("ERROR: Problem with data directory.", str(e))
         sys.exit(1)
 
     if playlist not in PLAYLISTS:
-        err('ERROR: Invalid playlist name: {playlist}')
+        err("ERROR: Invalid playlist name: {playlist}")
         sys.exit(1)
 
     if meta:
@@ -861,174 +874,186 @@ def import_cmd(data_dir, playlist, files, yes, meta=None, use_mtime=True,
                 if filename in metadata:
                     song_data[3].extend(
                         MetadataChange(key, metadata[filename][key])
-                        for key in 'artist title'.split()
+                        for key in "artist title".split()
                     )
 
                 analysis_data.append(song_data)
             else:
-                print('Ignoring', filename)
+                print("Ignoring", filename)
 
         except UnprocessableEntity as e:
-            err('WARNING: File cannot be analyzed: ' + filename)
-            err('WARNING: ' + e.description if hasattr(e, 'description')
-                else str(e))
+            err("WARNING: File cannot be analyzed: " + filename)
+            err("WARNING: " + e.description if hasattr(e, "description") else str(e))
         except Exception as e:  # pragma: no cover
-            err('WARNING: Unknown error when analyzing file: ' + filename)
-            err('WARNING: ' + e.description if hasattr(e, 'description')
-                else str(e))
+            err("WARNING: Unknown error when analyzing file: " + filename)
+            err("WARNING: " + e.description if hasattr(e, "description") else str(e))
 
-    print(f'Successfully analyzed {len(analysis_data)} of {len(files)} files.')
+    print(f"Successfully analyzed {len(analysis_data)} of {len(files)} files.")
     count = 0
-    if yes or input('Start import now? [y/N] ').strip().lower() == 'y':
+    if yes or input("Start import now? [y/N] ").strip().lower() == "y":
         for filename, fileId, ext, actions in analysis_data:
             try:
                 for processor in DEFAULT_PROCESSORS:
                     processor(data_dir, playlist, fileId, ext, actions)
                 count += 1
             except Exception as e:  # pragma: no cover
-                err('WARNING: File cannot be imported: ' + filename,
-                    e.description if hasattr(e, 'description')
-                    else str(e))
+                err(
+                    "WARNING: File cannot be imported: " + filename,
+                    e.description if hasattr(e, "description") else str(e),
+                )
 
-    print(f'Successfully imported {count} of {len(files)} files.')
+    print(f"Successfully imported {count} of {len(files)} files.")
     sys.exit(1 if count < len(files) else 0)
 
 
-def fsck_cmd(data_dir, repair=False, dev_mode=False):
-    """
-    Entry point for fsck script
-    """
+def fsck_cmd(data_dir, repair=False, dev_mode=False):  # noqa: C901
+    """Entry point for fsck script."""
+
     song_id = None
 
     def err(*args):
         if song_id is not None:
-            print('ERROR when processing', song_id, file=sys.stderr)
+            print("ERROR when processing", song_id, file=sys.stderr)
         print(*args, file=sys.stderr)
         err.count += 1
+
     err.count = 0
 
     try:
         _check_data_dir(data_dir)
     except Exception as e:
-        err('ERROR: Problem with data directory.', str(e))
+        err("ERROR: Problem with data directory.", str(e))
         sys.exit(1)
 
-    with locked_open(os.path.join(data_dir, 'index.json')) as f:
+    with locked_open(os.path.join(data_dir, "index.json")) as f:
         try:
             data = json.load(f)
         except ValueError as e:
-            err('ERROR: Cannot read index.json', str(e))
+            err("ERROR: Cannot read index.json", str(e))
             sys.exit(1)  # abort
 
         files = set()
         playlist_counts = collections.Counter()
         for playlist in PLAYLISTS:
-            files.update(os.path.join(playlist, entry) for entry in
-                         os.listdir(os.path.join(data_dir, playlist)))
-            with open(os.path.join(data_dir, playlist + '.m3u')) as f1:
-                playlist_counts.update(line.strip() for line in
-                                       f1.readlines())
+            files.update(
+                os.path.join(playlist, entry)
+                for entry in os.listdir(os.path.join(data_dir, playlist))
+            )
+            with open(os.path.join(data_dir, playlist + ".m3u")) as f1:
+                playlist_counts.update(line.strip() for line in f1.readlines())
         for song_id, entries in data.items():
             keys = set(entries.keys())
             missing = set(ALLOWED_METADATA.keys()) - keys
             if missing:
-                err('ERROR: missing entries:', ', '.join(missing))
-                continue   # cannot continue with missing entries
+                err("ERROR: missing entries:", ", ".join(missing))
+                continue  # cannot continue with missing entries
             too_many = keys - set(ALLOWED_METADATA.keys())
             if too_many:
-                err('ERROR: too many entries:', ', '.join(too_many))
+                err("ERROR: too many entries:", ", ".join(too_many))
             try:
-                check_processor(data_dir, entries['playlist'],
-                                entries['id'], entries['ext'],
-                                (MetadataChange(key, val)
-                                    for key, val in entries.items()))
+                check_processor(
+                    data_dir,
+                    entries["playlist"],
+                    entries["id"],
+                    entries["ext"],
+                    (MetadataChange(key, val) for key, val in entries.items()),
+                )
             except UnprocessableEntity as e:
-                err('ERROR:', str(e))
-            if song_id != entries['id']:
-                err('ERROR: Id missmatch', song_id, entries['id'])
-            if entries['cue_in'] > 10:
-                err('WARNING: cue_in after more than ten seconds:',
-                    entries['cue_in'])
-            if entries['cue_out'] < entries['length'] - 10:
-                err('WARNING: cue_out earlier than ten seconds before end of '
-                    'song:', entries['cue_out'])
-            if entries['cue_in'] > entries['cue_out']:
-                err('ERROR: cue_in larger than cue_out',
-                    str(entries['cue_in']),
-                    str(entries['cue_out']))
+                err("ERROR:", str(e))
+            if song_id != entries["id"]:
+                err("ERROR: Id missmatch", song_id, entries["id"])
+            if entries["cue_in"] > 10:
+                err("WARNING: cue_in after more than ten seconds:", entries["cue_in"])
+            if entries["cue_out"] < entries["length"] - 10:
+                err(
+                    "WARNING: cue_out earlier than ten seconds before end of " "song:",
+                    entries["cue_out"],
+                )
+            if entries["cue_in"] > entries["cue_out"]:
+                err(
+                    "ERROR: cue_in larger than cue_out",
+                    str(entries["cue_in"]),
+                    str(entries["cue_out"]),
+                )
             # Tolerate small differences, as the length calculation is not
             # perfectly accurate.
-            if entries['cue_out'] > entries['length'] + 0.1:
-                err('ERROR: cue_out larger than length',
-                    str(entries['cue_out']),
-                    str(entries['length']))
-            if entries['playlist'] != 'jingles' and entries['length'] < 30:
-                err('WARNING: very short song found:', entries['length'])
-            file_path = os.path.join(entries['playlist'],
-                                     entries['id'] + entries['ext'])
+            if entries["cue_out"] > entries["length"] + 0.1:
+                err(
+                    "ERROR: cue_out larger than length",
+                    str(entries["cue_out"]),
+                    str(entries["length"]),
+                )
+            if entries["playlist"] != "jingles" and entries["length"] < 30:
+                err("WARNING: very short song found:", entries["length"])
+            file_path = os.path.join(
+                entries["playlist"], entries["id"] + entries["ext"]
+            )
             file_full_path = os.path.join(data_dir, file_path)
             if not os.path.isfile(file_full_path):
-                err('ERROR: file does not exist:', file_full_path)
+                err("ERROR: file does not exist:", file_full_path)
             else:
                 files.remove(file_path)
-                FileType = SUPPORTED_FILE_TYPES[entries['ext']]
+                FileType = SUPPORTED_FILE_TYPES[entries["ext"]]
                 mutagenfile = FileType(file_full_path)
                 for key in TAG_KEYS:
-                    tag_value = mutagenfile.get(key, [''])[0]
+                    tag_value = mutagenfile.get(key, [""])[0]
                     if str(entries[key]) != tag_value:
-                        err(f"ERROR: Tag value mismatch '{key}': "
-                            f'{entries[key]} != {tag_value}')
+                        err(
+                            f"ERROR: Tag value mismatch '{key}': "
+                            f"{entries[key]} != {tag_value}"
+                        )
 
                 count = playlist_counts[file_path]
                 del playlist_counts[file_path]
-                if count != entries['weight']:
-                    err(f'ERROR: Playlist weight mismatch: '
-                        f"{entries['weight']} != {count}")
+                if count != entries["weight"]:
+                    err(
+                        f"ERROR: Playlist weight mismatch: "
+                        f"{entries['weight']} != {count}"
+                    )
 
         if files:
-            err('ERROR: Dangling files:', ', '.join(files))
+            err("ERROR: Dangling files:", ", ".join(files))
         if playlist_counts:
-            err('ERROR: Dangling playlist entry:',
-                ', '.join(playlist_counts.keys()))
+            err("ERROR: Dangling playlist entry:", ", ".join(playlist_counts.keys()))
 
     sys.exit(1 if err.count else 0)
 
 
 def playlog_cmd(data_dir, filename, off_air=False, dev_mode=False):
     if off_air:
-        with open(os.path.join(data_dir, 'log', 'current.json'), 'w') as f:
+        with open(os.path.join(data_dir, "log", "current.json"), "w") as f:
             json.dump(False, f)
         return
 
-    file_id = filename.split('/')[-1].split('.')[0]
+    file_id = filename.split("/")[-1].split(".")[0]
 
-    json_opts = {'indent': 2, 'sort_keys': True} if dev_mode else {}
+    json_opts = {"indent": 2, "sort_keys": True} if dev_mode else {}
 
     now = datetime.datetime.now()
 
-    with locked_open(os.path.join(data_dir, 'index.json')) as f:
+    with locked_open(os.path.join(data_dir, "index.json")) as f:
         data = json.load(f)
         entry = data[file_id]
-        entry['play_count'] = entry.get('play_count', 0) + 1
-        entry['last_play'] = now.isoformat()
+        entry["play_count"] = entry.get("play_count", 0) + 1
+        entry["last_play"] = now.isoformat()
         f.seek(0)
         f.truncate()
         json.dump(data, f, **json_opts)
         del data
 
-    with open(os.path.join(data_dir, 'log', 'current.json'), 'w') as f:
+    with open(os.path.join(data_dir, "log", "current.json"), "w") as f:
         json.dump(entry, f, **json_opts)
 
-    log_file_name = f'{now.year}-{now.month}.csv'
-    log_file_path = os.path.join(data_dir, 'log', log_file_name)
+    log_file_name = f"{now.year}-{now.month}.csv"
+    log_file_path = os.path.join(data_dir, "log", log_file_name)
 
     if not os.path.exists(log_file_path):
-        with open(log_file_path, 'w', newline='') as csv_file:
+        with open(log_file_path, "w", newline="") as csv_file:
             fieldnames = ALLOWED_METADATA.keys()
             writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
             writer.writeheader()
 
-    with open(log_file_path, 'a', newline='') as csv_file:
+    with open(log_file_path, "a", newline="") as csv_file:
         fieldnames = ALLOWED_METADATA.keys()
         writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
         writer.writerow(entry)
@@ -1037,106 +1062,119 @@ def playlog_cmd(data_dir, filename, off_air=False, dev_mode=False):
         subprocess.check_call(EXTERNAL_PLAY_LOGGER.format(**entry), shell=True)
 
 
-EXTERNAL_PLAY_LOGGER = os.environ.get('KLANGBECKEN_EXTERNAL_PLAY_LOGGER', '')
+EXTERNAL_PLAY_LOGGER = os.environ.get("KLANGBECKEN_EXTERNAL_PLAY_LOGGER", "")
 
 
 def reanalyze_cmd(data_dir, ids, all=False, yes=False, dev_mode=False):
-    with locked_open(os.path.join(data_dir, 'index.json')) as f:
+    with locked_open(os.path.join(data_dir, "index.json")) as f:
         data = json.load(f)
     if all:
         ids = data.keys()
 
     changes = []
     for id in ids:
-        playlist = data[id]['playlist']
-        ext = data[id]['ext']
+        playlist = data[id]["playlist"]
+        ext = data[id]["ext"]
         path = os.path.join(data_dir, playlist, id + ext)
         print(f'File: {path} ({data[id]["artist"]} - {data[id]["title"]})')
         with open(path) as f:
             file_changes = ffmpeg_audio_analyzer(playlist, id, ext, f)
         changes.append((playlist, id, ext, file_changes))
         for key, val in file_changes:
-            print(f' * {key}: {val}')
+            print(f" * {key}: {val}")
 
-    if yes or input('Apply changes now? [y/N] ').strip().lower() == 'y':
+    if yes or input("Apply changes now? [y/N] ").strip().lower() == "y":
         for playlist, id, ext, file_changes in changes:
             for processor in DEFAULT_PROCESSORS:
                 processor(data_dir, playlist, id, ext, file_changes)
 
 
 def main(dev_mode=False):
-    '''Klangbecken
+    """Klangbecken audio playout system.
 
-Usage:
-  klangbecken (--help | --version)
-  klangbecken init [-d DATA_DIR]
-  klangbecken serve [-d DATA_DIR] [-p PORT] [-b ADDRESS]
-  klangbecken import [-d DATA_DIR] [-y] [-m] [-M FILE] PLAYLIST FILE...
-  klangbecken fsck [-d DATA_DIR] [-R]
-  klangbecken playlog [-d DATA_DIR] (--off | FILE)
-  klangbecken reanalyze [-d DATA_DIR] [-y] (--all | ID...)
+    Usage:
+      klangbecken (--help | --version)
+      klangbecken init [-d DATA_DIR]
+      klangbecken serve [-d DATA_DIR] [-p PORT] [-b ADDRESS]
+      klangbecken import [-d DATA_DIR] [-y] [-m] [-M FILE] PLAYLIST FILE...
+      klangbecken fsck [-d DATA_DIR] [-R]
+      klangbecken playlog [-d DATA_DIR] (--off | FILE)
+      klangbecken reanalyze [-d DATA_DIR] [-y] (--all | ID...)
 
-Options:
-  -h, --help
-        Show this help message and exit.
-  --version
-        Show version and exit.
-  -d DIR, --data=DIR
-        Set data directory location [default: ./data/].
-  -p PORT, --port=PORT
-        Specify alternate port [default: 5000].
-  -b ADDRESS, --bind=ADDRESS
-        Specify alternate bind address [default: localhost].
-  -y, --yes
-        Automatically answer yes for all questions.
-  -m, --mtime
-        Use file modification date as import timestamp.
-  -M FILE, --meta=FILE
-        Read metadata from JSON file. Missing entries will be skipped.
-  -R, --repair
-        Try to repair index.
-  --off
-        Take klangbecken off the air.
-  --all
-        Reanalyze all files.
-'''
+    Options:
+      -h, --help
+            Show this help message and exit.
+      --version
+            Show version and exit.
+      -d DIR, --data=DIR
+            Set data directory location [default: ./data/].
+      -p PORT, --port=PORT
+            Specify alternate port [default: 5000].
+      -b ADDRESS, --bind=ADDRESS
+            Specify alternate bind address [default: localhost].
+      -y, --yes
+            Automatically answer yes for all questions.
+      -m, --mtime
+            Use file modification date as import timestamp.
+      -M FILE, --meta=FILE
+            Read metadata from JSON file. Missing entries will be skipped.
+      -R, --repair
+            Try to repair index.
+      --off
+            Take klangbecken off the air.
+      --all
+            Reanalyze all files.
+    """
     from docopt import docopt
-    args = docopt(main.__doc__, version=f'Klangbecken {__version__}')
 
-    data_dir = args['--data']
+    args = docopt(main.__doc__, version=f"Klangbecken {__version__}")
+
+    data_dir = args["--data"]
 
     if os.path.exists(data_dir) and not os.path.isdir(data_dir):
-        print(f"ERROR: Data directory '{data_dir}' exists, but is not a "
-              'directory.', file=sys.stderr)
+        print(
+            f"ERROR: Data directory '{data_dir}' exists, but is not a " "directory.",
+            file=sys.stderr,
+        )
         exit(1)
 
-    if not os.path.isdir(data_dir) and not args['init']:
-        print(f"ERROR: Data directory '{data_dir}' does not exist.",
-              file=sys.stderr)
+    if not os.path.isdir(data_dir) and not args["init"]:
+        print(f"ERROR: Data directory '{data_dir}' does not exist.", file=sys.stderr)
         exit(1)
 
-    if args['init']:
+    if args["init"]:
         init_cmd(data_dir)
-    elif args['serve']:
-        serve_cmd(data_dir, address=args['--bind'], port=int(args['--port']),
-                  dev_mode=dev_mode)
-    elif args['import']:
-        import_cmd(data_dir, args['PLAYLIST'], args['FILE'], yes=args['--yes'],
-                   meta=args['--meta'], use_mtime=args['--mtime'],
-                   dev_mode=dev_mode)
-    elif args['fsck']:
-        fsck_cmd(data_dir, repair=args['--repair'], dev_mode=dev_mode)
-    elif args['playlog']:
-        if args['--off']:
-            playlog_cmd(data_dir, '', args['--off'], dev_mode=dev_mode)
+    elif args["serve"]:
+        serve_cmd(
+            data_dir,
+            address=args["--bind"],
+            port=int(args["--port"]),
+            dev_mode=dev_mode,
+        )
+    elif args["import"]:
+        import_cmd(
+            data_dir,
+            args["PLAYLIST"],
+            args["FILE"],
+            yes=args["--yes"],
+            meta=args["--meta"],
+            use_mtime=args["--mtime"],
+            dev_mode=dev_mode,
+        )
+    elif args["fsck"]:
+        fsck_cmd(data_dir, repair=args["--repair"], dev_mode=dev_mode)
+    elif args["playlog"]:
+        if args["--off"]:
+            playlog_cmd(data_dir, "", args["--off"], dev_mode=dev_mode)
         else:
-            playlog_cmd(data_dir, args['FILE'][0], dev_mode=dev_mode)
-    elif args['reanalyze']:
-        reanalyze_cmd(data_dir, args['ID'], args['--all'], args['--yes'],
-                      dev_mode=dev_mode)
+            playlog_cmd(data_dir, args["FILE"][0], dev_mode=dev_mode)
+    elif args["reanalyze"]:
+        reanalyze_cmd(
+            data_dir, args["ID"], args["--all"], args["--yes"], dev_mode=dev_mode
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Enable development mode, when being called directly with
     # $ python klangbecken.py
     main(dev_mode=True)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,13 @@
+black==19.10b0
+codecov==2.1.3
+factory-boy==2.12.0
+flake8==3.8.2
+flake8-debugger==3.2.1
+flake8-docstrings==1.5.0
+flake8-isort==3.0.0
+flake8-string-format==0.3.0
+flake8-tuple==0.4.1
+isort==4.3.21
+mock==4.0.2
+pre-commit==2.4.0
+tox==3.15.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,44 @@
 [bdist_wheel]
 universal=1
 
+[isort]
+known_first_party=nowplaying
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+combine_as_imports=True
+line_length=88
+
 [flake8]
+ignore=
+    # whitespace before ':'
+    E203,
+    # too many leading ### in a block comment
+    E266,
+    # line too long (managed by black)
+    E501,
+    # Line break occurred before a binary operator (this is not PEP8 compatible)
+    W503,
+    # Missing docstring in public module
+    D100,
+    # Missing docstring in public class
+    D101,
+    # Missing docstring in public method
+    D102,
+    # Missing docstring in public function
+    D103,
+    # Missing docstring in public package
+    D104,
+    # Missing docstring in magic method
+    D105,
+    # Missing docstring in public package
+    D106,
+    # Missing docstring in __init__
+    D107,
+    # needed because of https://github.com/ambv/black/issues/144
+    D202,
+    # other string does contain unindexed parameters
+    P103
+max-line-length=80
 exclude=.venv,.tox
+max-complexity=10

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,35 @@
 from setuptools import setup
 
+
+def reqs(filename):
+    """Read reqs from files, hacky but ok since we don't distribute pypi packages."""
+    with open(filename) as f:
+        return f.read().splitlines()
+
+
 setup(
-    name='klangbecken',
-    version='0.0.12',
-    description='Klangbecken Audio Player',
-    url='https://github.com/radiorabe/klangbecken',
-    author='Marco Schmalz',
-    author_email='marco@schess.ch ',
-    py_modules=['klangbecken'],
-    license='AGPLv3',
+    name="klangbecken",
+    version="0.0.12",
+    description="Klangbecken Audio Player",
+    url="https://github.com/radiorabe/klangbecken",
+    author="Marco Schmalz",
+    author_email="marco@schess.ch ",
+    py_modules=["klangbecken"],
+    license="AGPLv3",
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU Affero General Public License v3',
-        'Operating System :: POSIX',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Topic :: Internet :: WWW/HTTP :: WSGI',
+        "Development Status :: 3 - Alpha",
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: GNU Affero General Public License v3",
+        "Operating System :: POSIX",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Topic :: Internet :: WWW/HTTP :: WSGI",
     ],
-    install_requires=['docopt', 'mutagen', 'PyJWT', 'Werkzeug'],
-    extras_require={
-        'test': ['tox', 'coverage', 'mock', 'flake8', 'python-dateutil'],
-    },
-    entry_points={
-        'console_scripts': ['klangbecken=klangbecken:main'],
-    }
+    install_requires=reqs("requirements.txt"),
+    extras_require={"test": reqs("requirements-dev.txt")},
+    entry_points={"console_scripts": ["klangbecken=klangbecken:main"]},
 )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,12 +1,12 @@
 import io
 import json
-import mock
 import os
 import shutil
 import tempfile
 import unittest
 import uuid
 
+import mock
 from werkzeug.datastructures import FileStorage
 from werkzeug.exceptions import NotFound, UnprocessableEntity
 from werkzeug.test import Client
@@ -16,24 +16,27 @@ from werkzeug.wrappers import BaseResponse
 class WSGIAppTest(unittest.TestCase):
     def test_application(self):
         from klangbecken import KlangbeckenAPI
-        application = KlangbeckenAPI('inexistent_dir', 'secret')
+
+        application = KlangbeckenAPI("inexistent_dir", "secret")
         self.assertTrue(callable(application))
 
 
 class APITestCase(unittest.TestCase):
     def setUp(self):
-        from klangbecken import (KlangbeckenAPI, FileAddition, MetadataChange)
+        from klangbecken import KlangbeckenAPI, FileAddition, MetadataChange
 
-        self.upload_analyzer = mock.Mock(return_value=[
-            FileAddition('testfile'),
-            MetadataChange('testkey', 'testvalue')
-        ])
-        self.update_analyzer = mock.Mock(return_value=['UpdateChange'])
+        self.upload_analyzer = mock.Mock(
+            return_value=[
+                FileAddition("testfile"),
+                MetadataChange("testkey", "testvalue"),
+            ]
+        )
+        self.update_analyzer = mock.Mock(return_value=["UpdateChange"])
         self.processor = mock.MagicMock()
 
         app = KlangbeckenAPI(
-            'data_dir',
-            'secret',
+            "data_dir",
+            "secret",
             upload_analyzers=[self.upload_analyzer],
             update_analyzers=[self.update_analyzer],
             processors=[self.processor],
@@ -42,53 +45,53 @@ class APITestCase(unittest.TestCase):
         self.client = Client(app, BaseResponse)
 
     def testUrls(self):
-        resp = self.client.get('/')
+        resp = self.client.get("/")
         self.assertEqual(resp.status_code, 404)
-        resp = self.client.get('/music/')
+        resp = self.client.get("/music/")
         self.assertEqual(resp.status_code, 405)
-        resp = self.client.get('/jingles/')
+        resp = self.client.get("/jingles/")
         self.assertEqual(resp.status_code, 405)
-        resp = self.client.get('/nonexistant/')
+        resp = self.client.get("/nonexistant/")
         self.assertEqual(resp.status_code, 404)
-        resp = self.client.get('/öäü/')
+        resp = self.client.get("/öäü/")
         self.assertEqual(resp.status_code, 404)
-        resp = self.client.post('/jingles')
+        resp = self.client.post("/jingles")
         self.assertIn(resp.status_code, (301, 308))
-        resp = self.client.post('/music/')
+        resp = self.client.post("/music/")
         self.assertEqual(resp.status_code, 422)
-        resp = self.client.post('/jingles/something')
+        resp = self.client.post("/jingles/something")
         self.assertEqual(resp.status_code, 404)
-        resp = self.client.put('/music/')
+        resp = self.client.put("/music/")
         self.assertEqual(resp.status_code, 405)
-        resp = self.client.put('/jingles/something')
+        resp = self.client.put("/jingles/something")
         self.assertEqual(resp.status_code, 404)
-        resp = self.client.put('/jingles/something.mp3')
+        resp = self.client.put("/jingles/something.mp3")
         self.assertEqual(resp.status_code, 404)
-        resp = self.client.put('/music/' + str(uuid.uuid4()))
+        resp = self.client.put("/music/" + str(uuid.uuid4()))
         self.assertEqual(resp.status_code, 404)
-        resp = self.client.put('/music/' + str(uuid.uuid4()) + '.mp3')
+        resp = self.client.put("/music/" + str(uuid.uuid4()) + ".mp3")
         self.assertEqual(resp.status_code, 422)
-        resp = self.client.put('/jingles/' + str(uuid.uuid4()) + '.ogg')
+        resp = self.client.put("/jingles/" + str(uuid.uuid4()) + ".ogg")
         self.assertEqual(resp.status_code, 422)
-        resp = self.client.put('/music/' + str(uuid.uuid4()) + '.flac')
+        resp = self.client.put("/music/" + str(uuid.uuid4()) + ".flac")
         self.assertEqual(resp.status_code, 422)
-        resp = self.client.put('/jingles/' + str(uuid.uuid4()) + '.ttt')
+        resp = self.client.put("/jingles/" + str(uuid.uuid4()) + ".ttt")
         self.assertEqual(resp.status_code, 404)
-        resp = self.client.delete('/music/')
+        resp = self.client.delete("/music/")
         self.assertEqual(resp.status_code, 405)
-        resp = self.client.delete('/jingles/something')
+        resp = self.client.delete("/jingles/something")
         self.assertEqual(resp.status_code, 404)
-        resp = self.client.delete('/jingles/something.mp3')
+        resp = self.client.delete("/jingles/something.mp3")
         self.assertEqual(resp.status_code, 404)
-        resp = self.client.delete('/music/' + str(uuid.uuid4()))
+        resp = self.client.delete("/music/" + str(uuid.uuid4()))
         self.assertEqual(resp.status_code, 404)
-        resp = self.client.delete('/jingles/' + str(uuid.uuid4()) + '.mp3')
+        resp = self.client.delete("/jingles/" + str(uuid.uuid4()) + ".mp3")
         self.assertEqual(resp.status_code, 200)
-        resp = self.client.delete('/music/' + str(uuid.uuid4()) + '.ogg')
+        resp = self.client.delete("/music/" + str(uuid.uuid4()) + ".ogg")
         self.assertEqual(resp.status_code, 200)
-        resp = self.client.delete('/jingles/' + str(uuid.uuid4()) + '.flac')
+        resp = self.client.delete("/jingles/" + str(uuid.uuid4()) + ".flac")
         self.assertEqual(resp.status_code, 200)
-        resp = self.client.delete('/music/' + str(uuid.uuid4()) + '.ttt')
+        resp = self.client.delete("/music/" + str(uuid.uuid4()) + ".ttt")
         self.assertEqual(resp.status_code, 404)
 
     def testUpload(self):
@@ -96,28 +99,30 @@ class APITestCase(unittest.TestCase):
 
         # Correct upload
         resp = self.client.post(
-            '/music/',
-            data={'file': (io.BytesIO(b'testcontent'), 'test.mp3')},
+            "/music/", data={"file": (io.BytesIO(b"testcontent"), "test.mp3")}
         )
         self.assertEqual(resp.status_code, 200)
         data = json.loads(resp.data)
         fileId = list(data.keys())[0]
         self.assertEqual(fileId, str(uuid.UUID(fileId)))
-        self.assertEqual(list(data.values())[0], {'testkey': 'testvalue'})
+        self.assertEqual(list(data.values())[0], {"testkey": "testvalue"})
         self.update_analyzer.assert_not_called()
         self.upload_analyzer.assert_called_once()
         args = self.upload_analyzer.call_args[0]
-        self.assertEqual(args[0], 'music')
+        self.assertEqual(args[0], "music")
         self.assertEqual(args[1], fileId)
-        self.assertEqual(args[2], '.mp3')
+        self.assertEqual(args[2], ".mp3")
         self.assertTrue(isinstance(args[3], FileStorage))
-        self.assertEqual(args[3].filename, 'test.mp3')
-        self.assertEqual(args[3].mimetype, 'audio/mpeg')
+        self.assertEqual(args[3].filename, "test.mp3")
+        self.assertEqual(args[3].mimetype, "audio/mpeg")
         self.assertTrue(args[3].closed)
 
         self.processor.assert_called_once_with(
-            'data_dir', 'music', fileId, '.mp3',
-            [FileAddition('testfile'), MetadataChange('testkey', 'testvalue')]
+            "data_dir",
+            "music",
+            fileId,
+            ".mp3",
+            [FileAddition("testfile"), MetadataChange("testkey", "testvalue")],
         )
 
         self.upload_analyzer.reset_mock()
@@ -125,22 +130,20 @@ class APITestCase(unittest.TestCase):
 
         # Wrong attribute name
         resp = self.client.post(
-            '/music/',
-            data={'not-file': (io.BytesIO(b'testcontent'), 'test.mp3')},
+            "/music/", data={"not-file": (io.BytesIO(b"testcontent"), "test.mp3")}
         )
         self.assertEqual(resp.status_code, 422)
-        self.assertTrue(b'No attribute named \'file\' found' in resp.data)
+        self.assertTrue(b"No attribute named 'file' found" in resp.data)
         self.update_analyzer.assert_not_called()
         self.upload_analyzer.assert_not_called()
         self.processor.assert_not_called()
 
         # File as normal text attribute
         resp = self.client.post(
-            '/music/',
-            data={'file': 'testcontent', 'filename': 'test.mp3'},
+            "/music/", data={"file": "testcontent", "filename": "test.mp3"}
         )
         self.assertEqual(resp.status_code, 422)
-        self.assertTrue(b'No attribute named \'file\' found' in resp.data)
+        self.assertTrue(b"No attribute named 'file' found" in resp.data)
         self.update_analyzer.assert_not_called()
         self.upload_analyzer.assert_not_called()
         self.processor.assert_not_called()
@@ -149,104 +152,90 @@ class APITestCase(unittest.TestCase):
         # Update weight correctly
         fileId = str(uuid.uuid4())
         resp = self.client.put(
-            '/music/' + fileId + '.mp3',
-            data=json.dumps({'weight': 4}),
-            content_type='text/json'
+            "/music/" + fileId + ".mp3",
+            data=json.dumps({"weight": 4}),
+            content_type="text/json",
         )
         self.assertEqual(resp.status_code, 200)
-        self.update_analyzer.assert_called_once_with('music', fileId, '.mp3',
-                                                     {'weight': 4})
+        self.update_analyzer.assert_called_once_with(
+            "music", fileId, ".mp3", {"weight": 4}
+        )
         self.upload_analyzer.assert_not_called()
-        self.processor.assert_called_once_with('data_dir', 'music', fileId,
-                                               '.mp3', ['UpdateChange'])
-        self.assertEqual(json.loads(resp.data),
-                         {'status': 'OK'})
+        self.processor.assert_called_once_with(
+            "data_dir", "music", fileId, ".mp3", ["UpdateChange"]
+        )
+        self.assertEqual(json.loads(resp.data), {"status": "OK"})
         self.update_analyzer.reset_mock()
         self.processor.reset_mock()
 
         # Update artist and title correctly
         resp = self.client.put(
-            '/music/' + fileId + '.mp3',
-            data=json.dumps({'artist': 'A', 'title': 'B'}),
-            content_type='text/json'
+            "/music/" + fileId + ".mp3",
+            data=json.dumps({"artist": "A", "title": "B"}),
+            content_type="text/json",
         )
         self.assertEqual(resp.status_code, 200)
         self.update_analyzer.assert_called_once_with(
-            'music', fileId, '.mp3', {'artist': 'A', 'title': 'B'}
+            "music", fileId, ".mp3", {"artist": "A", "title": "B"}
         )
         self.processor.assert_called_once_with(
-            'data_dir', 'music', fileId, '.mp3',
-            ['UpdateChange']
+            "data_dir", "music", fileId, ".mp3", ["UpdateChange"]
         )
         self.update_analyzer.reset_mock()
         self.processor.reset_mock()
 
         # Update with invalid json format
         resp = self.client.put(
-            '/music/' + fileId + '.mp3',
-            data='{ a: " }',
-            content_type='text/json'
+            "/music/" + fileId + ".mp3", data='{ a: " }', content_type="text/json"
         )
         self.assertEqual(resp.status_code, 422)
-        self.assertIn(b'invalid JSON', resp.data)
+        self.assertIn(b"invalid JSON", resp.data)
         self.update_analyzer.assert_not_called()
 
         # Update with invalid unicode format
         resp = self.client.put(
-            '/music/' + fileId + '.mp3',
-            data=b'\xFF',
-            content_type='text/json'
+            "/music/" + fileId + ".mp3", data=b"\xFF", content_type="text/json"
         )
         self.assertEqual(resp.status_code, 422)
-        self.assertIn(b'invalid UTF-8 data', resp.data)
+        self.assertIn(b"invalid UTF-8 data", resp.data)
         self.update_analyzer.assert_not_called()
 
     def testDelete(self):
         from klangbecken import FileDeletion
+
         fileId = str(uuid.uuid4())
-        resp = self.client.delete('/music/' + fileId + '.mp3',)
+        resp = self.client.delete("/music/" + fileId + ".mp3")
         self.assertEqual(resp.status_code, 200)
         self.update_analyzer.assert_not_called()
         self.upload_analyzer.assert_not_called()
-        self.processor.assert_called_once_with('data_dir', 'music', fileId,
-                                               '.mp3', [FileDeletion()])
+        self.processor.assert_called_once_with(
+            "data_dir", "music", fileId, ".mp3", [FileDeletion()]
+        )
 
-        self.assertEqual(json.loads(resp.data),
-                         {'status': 'OK'})
+        self.assertEqual(json.loads(resp.data), {"status": "OK"})
         self.upload_analyzer.reset_mock()
         self.processor.reset_mock()
 
-    @mock.patch('klangbecken.playnext_processor')
+    @mock.patch("klangbecken.playnext_processor")
     def testPlaynext(self, playnext_processor):
         # Update weight correctly
         resp = self.client.post(
-            '/playnext/',
-            data=json.dumps({'file': 'tutu'}),
-            content_type='text/json'
+            "/playnext/", data=json.dumps({"file": "tutu"}), content_type="text/json"
         )
         self.assertEqual(resp.status_code, 200)
-        playnext_processor.assert_called_once_with('data_dir',
-                                                   {'file': 'tutu'})
+        playnext_processor.assert_called_once_with("data_dir", {"file": "tutu"})
         playnext_processor.reset_mock()
 
         # Update with invalid json format
-        resp = self.client.post(
-            '/playnext/',
-            data='{ a: " }',
-            content_type='text/json'
-        )
+        resp = self.client.post("/playnext/", data='{ a: " }', content_type="text/json")
         self.assertEqual(resp.status_code, 422)
-        self.assertTrue(b'invalid JSON' in resp.data)
+        self.assertTrue(b"invalid JSON" in resp.data)
         playnext_processor.assert_not_called()
 
         # Update with invalid unicode format
-        resp = self.client.post(
-            '/playnext/',
-            data=b'\xFF',
-            content_type='text/json'
-        )
+        resp = self.client.post("/playnext/", data=b"\xFF", content_type="text/json")
         self.assertEqual(resp.status_code, 422)
-        self.assertTrue(b'invalid UTF-8 data' in resp.data)
+        self.assertTrue(b"invalid UTF-8 data" in resp.data)
         playnext_processor.assert_not_called()
 
 
@@ -255,8 +244,8 @@ class AuthTestCase(unittest.TestCase):
         from klangbecken import KlangbeckenAPI
 
         app = KlangbeckenAPI(
-            'inexistent_dir',
-            'secret',
+            "inexistent_dir",
+            "secret",
             upload_analyzers=[lambda *args: []],
             update_analyzers=[lambda *args: []],
             processors=[lambda *args: None],
@@ -264,37 +253,35 @@ class AuthTestCase(unittest.TestCase):
         self.client = Client(app, BaseResponse)
 
     def testFailingAuth(self):
-        resp = self.client.post('/music/')
+        resp = self.client.post("/music/")
         self.assertEqual(resp.status_code, 401)
-        resp = self.client.put('/jingles/' + str(uuid.uuid4()) + '.mp3')
+        resp = self.client.put("/jingles/" + str(uuid.uuid4()) + ".mp3")
         self.assertEqual(resp.status_code, 401)
-        resp = self.client.delete('/music/' + str(uuid.uuid4()) + '.ogg')
+        resp = self.client.delete("/music/" + str(uuid.uuid4()) + ".ogg")
         self.assertEqual(resp.status_code, 401)
 
     def testFailingLogin(self):
-        resp = self.client.get('/auth/login/')
+        resp = self.client.get("/auth/login/")
         self.assertEqual(resp.status_code, 401)
-        self.assertNotIn('Set-Cookie', resp.headers)
+        self.assertNotIn("Set-Cookie", resp.headers)
 
-        resp = self.client.post('/auth/login/')
+        resp = self.client.post("/auth/login/")
         self.assertEqual(resp.status_code, 401)
-        self.assertNotIn('Set-Cookie', resp.headers)
+        self.assertNotIn("Set-Cookie", resp.headers)
 
     def testLogin(self):
-        resp = self.client.post('/auth/login/',
-                                environ_base={'REMOTE_USER': 'xyz'})
+        resp = self.client.post("/auth/login/", environ_base={"REMOTE_USER": "xyz"})
         self.assertEqual(resp.status_code, 200)
         response_data = json.loads(resp.data)
-        self.assertIn('token', response_data)
-        self.assertRegex(response_data['token'],
-                         r'([a-zA-Z0-9_-]+\.){2}[a-zA-Z0-9_-]+')
+        self.assertIn("token", response_data)
+        self.assertRegex(response_data["token"], r"([a-zA-Z0-9_-]+\.){2}[a-zA-Z0-9_-]+")
 
 
 class AnalyzersTestCase(unittest.TestCase):
     def setUp(self):
         self.current_path = os.path.dirname(os.path.realpath(__file__))
         fd, name = tempfile.mkstemp()
-        os.write(fd, b'\0' * 1024)
+        os.write(fd, b"\0" * 1024)
         os.close(fd)
         self.invalid_file = name
 
@@ -306,152 +293,162 @@ class AnalyzersTestCase(unittest.TestCase):
 
         # Correct single update
         self.assertEqual(
-            update_data_analyzer('playlist', 'id', '.ext', {'artist': 'A'}),
-            [MetadataChange('artist', 'A')]
+            update_data_analyzer("playlist", "id", ".ext", {"artist": "A"}),
+            [MetadataChange("artist", "A")],
         )
 
         # Correct multiple updates
-        changes = update_data_analyzer('playlist', 'id', '.ext',
-                                       {'artist': 'A', 'title': 'Ø'})
+        changes = update_data_analyzer(
+            "playlist", "id", ".ext", {"artist": "A", "title": "Ø"}
+        )
         self.assertEqual(len(changes), 2)
-        self.assertTrue(MetadataChange('artist', 'A') in changes)
-        self.assertTrue(MetadataChange('title', 'Ø') in changes)
+        self.assertTrue(MetadataChange("artist", "A") in changes)
+        self.assertTrue(MetadataChange("title", "Ø") in changes)
 
         # Update not allowed property (original_filename)
         self.assertRaises(
             UnprocessableEntity,
             update_data_analyzer,
-            'playlist', 'id', '.ext', {'original_filename': 'test.mp3'}
+            "playlist",
+            "id",
+            ".ext",
+            {"original_filename": "test.mp3"},
         )
 
         # Update with wrong data format
         self.assertRaises(
             UnprocessableEntity,
             update_data_analyzer,
-            'playlist', 'id', '.ext', [['artist', 'A']]
+            "playlist",
+            "id",
+            ".ext",
+            [["artist", "A"]],
         )
 
     def testRawFileAnalyzer(self):
         import datetime
         import dateutil.parser
-        from klangbecken import (raw_file_analyzer, FileAddition,
-                                 MetadataChange)
+        from klangbecken import raw_file_analyzer, FileAddition, MetadataChange
 
         # Missing file
-        self.assertRaises(UnprocessableEntity, raw_file_analyzer, 'music',
-                          'fileId', '.mp3', None)
+        self.assertRaises(
+            UnprocessableEntity, raw_file_analyzer, "music", "fileId", ".mp3", None
+        )
 
         # Invalid file
-        self.assertRaises(UnprocessableEntity, raw_file_analyzer,
-                          'music', 'fileId', '.xml', 'file')
+        self.assertRaises(
+            UnprocessableEntity, raw_file_analyzer, "music", "fileId", ".xml", "file"
+        )
 
         # Correct file
-        fileStorage = FileStorage(filename='filename-äöü')
-        result = raw_file_analyzer('jingles', 'fileId', '.ogg', fileStorage)
+        fileStorage = FileStorage(filename="filename-äöü")
+        result = raw_file_analyzer("jingles", "fileId", ".ogg", fileStorage)
 
         # Assure file is reset correctly
         self.assertEqual(fileStorage.tell(), 0)
         self.assertFalse(fileStorage.closed)
 
         self.assertEqual(result[0], FileAddition(fileStorage))
-        self.assertTrue(MetadataChange('playlist', 'jingles') in result)
-        self.assertTrue(MetadataChange('id', 'fileId') in result)
-        self.assertTrue(MetadataChange('ext', '.ogg') in result)
-        self.assertTrue(MetadataChange('original_filename', 'filename-äöü') in
-                        result)
-        t = [ch for ch in result if (isinstance(ch, MetadataChange) and
-                                     ch.key == 'import_timestamp')][0]
+        self.assertTrue(MetadataChange("playlist", "jingles") in result)
+        self.assertTrue(MetadataChange("id", "fileId") in result)
+        self.assertTrue(MetadataChange("ext", ".ogg") in result)
+        self.assertTrue(MetadataChange("original_filename", "filename-äöü") in result)
+        t = [
+            ch
+            for ch in result
+            if (isinstance(ch, MetadataChange) and ch.key == "import_timestamp")
+        ][0]
         t = dateutil.parser.parse(t.value)
-        self.assertTrue(datetime.datetime.now() - t
-                        < datetime.timedelta(seconds=2))
-        self.assertTrue(MetadataChange('weight', 1) in result)
+        self.assertTrue(datetime.datetime.now() - t < datetime.timedelta(seconds=2))
+        self.assertTrue(MetadataChange("weight", 1) in result)
 
     def testMutagenTagAnalyzer(self):
         from klangbecken import mutagen_tag_analyzer
         from klangbecken import MetadataChange as Change
 
         # Test regular files
-        for ext in ['.mp3', '.ogg', '.flac']:
-            path = os.path.join(self.current_path, 'audio', 'silence' + ext)
-            with open(path, 'rb') as f:
+        for ext in [".mp3", ".ogg", ".flac"]:
+            path = os.path.join(self.current_path, "audio", "silence" + ext)
+            with open(path, "rb") as f:
                 fs = FileStorage(f)
-                changes = mutagen_tag_analyzer('music', 'fileId', ext, fs)
+                changes = mutagen_tag_analyzer("music", "fileId", ext, fs)
                 self.assertEqual(len(changes), 4)
-                self.assertIn(Change('artist', 'Silence Artist'), changes)
-                self.assertIn(Change('title', 'Silence Track'), changes)
-                self.assertIn(Change('album', 'Silence Album'), changes)
-                self.assertIn(Change('length', 1.0), changes)
+                self.assertIn(Change("artist", "Silence Artist"), changes)
+                self.assertIn(Change("title", "Silence Track"), changes)
+                self.assertIn(Change("album", "Silence Album"), changes)
+                self.assertIn(Change("length", 1.0), changes)
 
                 # Assure file is reset correctly
                 self.assertEqual(f.tell(), 0)
                 self.assertFalse(f.closed)
 
         # Test regular files with unicode tags
-        for suffix in ['-jointstereo.mp3', '-stereo.mp3', '.ogg', '.flac']:
-            extra, ext = suffix.split('.')
-            ext = '.' + ext
-            name = 'silence-unicode' + extra + ext
-            path = os.path.join(self.current_path, 'audio', name)
-            with open(path, 'rb') as f:
+        for suffix in ["-jointstereo.mp3", "-stereo.mp3", ".ogg", ".flac"]:
+            extra, ext = suffix.split(".")
+            ext = "." + ext
+            name = "silence-unicode" + extra + ext
+            path = os.path.join(self.current_path, "audio", name)
+            with open(path, "rb") as f:
                 fs = FileStorage(f)
-                changes = mutagen_tag_analyzer('music', 'fileId', ext, fs)
+                changes = mutagen_tag_analyzer("music", "fileId", ext, fs)
                 self.assertEqual(len(changes), 4)
-                self.assertIn(Change('artist', 'ÀÉÈ'), changes)
-                self.assertIn(Change('title', 'ÄÖÜ'), changes)
-                self.assertIn(Change('album', '☀⚛♬'), changes)
-                self.assertIn(Change('length', 1.0), changes)
+                self.assertIn(Change("artist", "ÀÉÈ"), changes)
+                self.assertIn(Change("title", "ÄÖÜ"), changes)
+                self.assertIn(Change("album", "☀⚛♬"), changes)
+                self.assertIn(Change("length", 1.0), changes)
 
         # Test MP3 without any tags
-        path = os.path.join(self.current_path, 'audio', 'silence-stripped.mp3')
-        with open(path, 'rb') as f:
+        path = os.path.join(self.current_path, "audio", "silence-stripped.mp3")
+        with open(path, "rb") as f:
             fs = FileStorage(f)
-            changes = mutagen_tag_analyzer('music', 'fileId', '.mp3', fs)
+            changes = mutagen_tag_analyzer("music", "fileId", ".mp3", fs)
             self.assertEqual(len(changes), 4)
-            self.assertIn(Change('artist', ''), changes)
-            self.assertIn(Change('title', ''), changes)
-            self.assertIn(Change('album', ''), changes)
-            self.assertIn(Change('length', 1.0), changes)
+            self.assertIn(Change("artist", ""), changes)
+            self.assertIn(Change("title", ""), changes)
+            self.assertIn(Change("album", ""), changes)
+            self.assertIn(Change("length", 1.0), changes)
 
         # Test invalid files
-        for ext in ['.mp3', '.ogg', '.flac']:
-            path = os.path.join(self.current_path, 'audio', 'silence' + ext)
-            fs = FileStorage(io.BytesIO(b'\0' * 1024))
+        for ext in [".mp3", ".ogg", ".flac"]:
+            path = os.path.join(self.current_path, "audio", "silence" + ext)
+            fs = FileStorage(io.BytesIO(b"\0" * 1024))
             with self.assertRaises(UnprocessableEntity):
-                mutagen_tag_analyzer('music', 'fileId', ext, fs)
+                mutagen_tag_analyzer("music", "fileId", ext, fs)
 
     def _analyzeOneFile(self, prefix, postfix, gain, cue_in, cue_out):
         from klangbecken import ffmpeg_audio_analyzer
         from klangbecken import MetadataChange
 
-        name = prefix + postfix.split('.')[0]
-        ext = '.' + postfix.split('.')[1]
+        name = prefix + postfix.split(".")[0]
+        ext = "." + postfix.split(".")[1]
 
         current_path = os.path.dirname(os.path.realpath(__file__))
-        path = os.path.join(current_path, 'audio', name + ext)
-        with open(path, 'rb') as f:
+        path = os.path.join(current_path, "audio", name + ext)
+        with open(path, "rb") as f:
             fs = FileStorage(f)
 
-            changes = ffmpeg_audio_analyzer('music', name, ext, fs)
+            changes = ffmpeg_audio_analyzer("music", name, ext, fs)
             self.assertEqual(len(changes), 3)
             for change in changes:
                 self.assertIsInstance(change, MetadataChange)
             changes = {key: val for key, val in changes}
-            self.assertEqual(set(changes.keys()),
-                             set('track_gain cue_in cue_out'.split()))
+            self.assertEqual(
+                set(changes.keys()), set("track_gain cue_in cue_out".split())
+            )
 
             # Track gain negativ and with units
-            measured_gain = changes['track_gain']
-            self.assertTrue(measured_gain.endswith(' dB'))
+            measured_gain = changes["track_gain"]
+            self.assertTrue(measured_gain.endswith(" dB"))
 
             # Be within ±0.5 dB of expected gain value
             self.assertLess(abs(float(measured_gain[:-3]) - gain), 0.5)
 
             # Be within the expected values for cue points
             # Don't fade in late, or fade out early!
-            self.assertGreater(float(changes['cue_in']), cue_in - 0.1)
-            self.assertLess(float(changes['cue_in']), cue_in + 0.01)
-            self.assertGreater(float(changes['cue_out']), cue_out - 0.02)
-            self.assertLess(float(changes['cue_out']), cue_out + 0.1)
+            self.assertGreater(float(changes["cue_in"]), cue_in - 0.1)
+            self.assertLess(float(changes["cue_in"]), cue_in + 0.01)
+            self.assertGreater(float(changes["cue_out"]), cue_out - 0.02)
+            self.assertLess(float(changes["cue_out"]), cue_out + 0.1)
 
             # Assure file is reset correctly
             self.assertEqual(f.tell(), 0)
@@ -461,66 +458,41 @@ class AnalyzersTestCase(unittest.TestCase):
         from klangbecken import ffmpeg_audio_analyzer
 
         test_data = [
-            {
-                'prefix': 'padded',
-                'gain': -17,
-                'cue_in': 0.2,
-                'cue_out': 0.8,
-            },
-            {
-                'prefix': 'padded-start',
-                'gain': -3.33,
-                'cue_in': 1,
-                'cue_out': 2,
-            },
-            {
-                'prefix': 'padded-end',
-                'gain': -3.55,
-                'cue_in': 0,
-                'cue_out': 1,
-            },
-            {
-                'prefix': 'silence-unicode',
-                'gain': +64,
-                'cue_in': 0,
-                'cue_out': 0,
-            },
-            {
-                'prefix': 'interleaved',
-                'gain': -14.16,
-                'cue_in': 0.2,
-                'cue_out': 0.8,
-            },
+            {"prefix": "padded", "gain": -17, "cue_in": 0.2, "cue_out": 0.8},
+            {"prefix": "padded-start", "gain": -3.33, "cue_in": 1, "cue_out": 2},
+            {"prefix": "padded-end", "gain": -3.55, "cue_in": 0, "cue_out": 1},
+            {"prefix": "silence-unicode", "gain": +64, "cue_in": 0, "cue_out": 0},
+            {"prefix": "interleaved", "gain": -14.16, "cue_in": 0.2, "cue_out": 0.8},
         ]
 
         for data in test_data:
-            for ext in '-jointstereo.mp3 -stereo.mp3 .ogg .flac'.split():
+            for ext in "-jointstereo.mp3 -stereo.mp3 .ogg .flac".split():
                 self._analyzeOneFile(postfix=ext, **data)
 
         # invalid file
         with self.assertRaises(UnprocessableEntity):
-            with open(self.invalid_file, 'rb') as f:
+            with open(self.invalid_file, "rb") as f:
                 fs = FileStorage(f)
-                ffmpeg_audio_analyzer('music', 'id1', '.mp3', fs)
+                ffmpeg_audio_analyzer("music", "id1", ".mp3", fs)
 
 
 class ProcessorsTestCase(unittest.TestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
-        os.mkdir(os.path.join(self.tempdir, 'music'))
+        os.mkdir(os.path.join(self.tempdir, "music"))
 
         current_path = os.path.dirname(os.path.realpath(__file__))
-        for ext in '.mp3 -stripped.mp3 .ogg .flac'.split():
+        for ext in ".mp3 -stripped.mp3 .ogg .flac".split():
             shutil.copyfile(
-                os.path.join(current_path, 'audio', 'silence' + ext),
-                os.path.join(self.tempdir, 'music', 'silence' + ext)
+                os.path.join(current_path, "audio", "silence" + ext),
+                os.path.join(self.tempdir, "music", "silence" + ext),
             )
 
-        with open(os.path.join(self.tempdir, 'index.json'), 'w') as f:
-            print('{}', file=f)
-        open(os.path.join(self.tempdir, 'music.m3u'), 'w').close()
-        open(os.path.join(self.tempdir, 'jingles.m3u'), 'w').close()
-        open(os.path.join(self.tempdir, 'prio.m3u'), 'w').close()
+        with open(os.path.join(self.tempdir, "index.json"), "w") as f:
+            print("{}", file=f)
+        open(os.path.join(self.tempdir, "music.m3u"), "w").close()
+        open(os.path.join(self.tempdir, "jingles.m3u"), "w").close()
+        open(os.path.join(self.tempdir, "prio.m3u"), "w").close()
 
     def tearDown(self):
         shutil.rmtree(self.tempdir)
@@ -530,184 +502,222 @@ class ProcessorsTestCase(unittest.TestCase):
 
         # Invalid key
         with self.assertRaises(UnprocessableEntity) as cm:
-            check_processor(self.tempdir, 'playlist', 'id', '.ext',
-                            [MetadataChange('invalid', 'xyz')])
-        self.assertTrue('Invalid metadata key' in cm.exception.description)
+            check_processor(
+                self.tempdir,
+                "playlist",
+                "id",
+                ".ext",
+                [MetadataChange("invalid", "xyz")],
+            )
+        self.assertTrue("Invalid metadata key" in cm.exception.description)
 
         # Wrong data type (str instead of int)
         with self.assertRaises(UnprocessableEntity) as cm:
-            check_processor(self.tempdir, 'playlist', 'id', '.ext',
-                            [MetadataChange('weight', '1')])
-        self.assertTrue('Invalid data format' in cm.exception.description)
+            check_processor(
+                self.tempdir, "playlist", "id", ".ext", [MetadataChange("weight", "1")]
+            )
+        self.assertTrue("Invalid data format" in cm.exception.description)
 
         # Wrong data format (uuid)
         with self.assertRaises(UnprocessableEntity) as cm:
-            check_processor(self.tempdir, 'playlist', 'id', '.ext',
-                            [MetadataChange('id', 'xyz')])
-        self.assertTrue('Invalid data format' in cm.exception.description)
-        self.assertTrue('Regex' in cm.exception.description)
+            check_processor(
+                self.tempdir, "playlist", "id", ".ext", [MetadataChange("id", "xyz")]
+            )
+        self.assertTrue("Invalid data format" in cm.exception.description)
+        self.assertTrue("Regex" in cm.exception.description)
 
         # Wrong data format (negative length)
         with self.assertRaises(UnprocessableEntity) as cm:
-            check_processor(self.tempdir, 'playlist', 'id', '.ext',
-                            [MetadataChange('length', -5.0)])
-        self.assertTrue('Invalid data format' in cm.exception.description)
+            check_processor(
+                self.tempdir, "playlist", "id", ".ext", [MetadataChange("length", -5.0)]
+            )
+        self.assertTrue("Invalid data format" in cm.exception.description)
 
         # Invalid action class
         with self.assertRaises(ValueError) as cm:
-            check_processor(self.tempdir, 'playlist', 'id', '.ext',
-                            ['whatever'])
+            check_processor(self.tempdir, "playlist", "id", ".ext", ["whatever"])
 
     def testFilterDuplicatesProcessor(self):
         from klangbecken import filter_duplicates_processor
         from klangbecken import index_processor
         from klangbecken import FileAddition, MetadataChange
 
-        file_ = FileStorage(io.BytesIO(b'abc'), 'filename.mp3')
+        file_ = FileStorage(io.BytesIO(b"abc"), "filename.mp3")
         changes = [
             FileAddition(file_),
-            MetadataChange('original_filename', 'filename.mp3'),
-            MetadataChange('artist', 'Artist'),
-            MetadataChange('title', 'Title'),
-            MetadataChange('playlist', 'music'),
+            MetadataChange("original_filename", "filename.mp3"),
+            MetadataChange("artist", "Artist"),
+            MetadataChange("title", "Title"),
+            MetadataChange("playlist", "music"),
         ]
-        filter_duplicates_processor(self.tempdir, 'music', 'id1', '.mp3',
-                                    changes)
+        filter_duplicates_processor(self.tempdir, "music", "id1", ".mp3", changes)
 
-        index_processor(self.tempdir, 'music', 'id1', '.mp3',
-                        changes)
+        index_processor(self.tempdir, "music", "id1", ".mp3", changes)
         with self.assertRaises(UnprocessableEntity) as cm:
-            filter_duplicates_processor(self.tempdir, 'music', 'id', '.mp3',
-                                        changes)
-        self.assertTrue('Duplicate file entry' in cm.exception.description)
+            filter_duplicates_processor(self.tempdir, "music", "id", ".mp3", changes)
+        self.assertTrue("Duplicate file entry" in cm.exception.description)
 
     def testRawFileProcessor(self):
         from klangbecken import raw_file_processor
         from klangbecken import FileAddition, FileDeletion, MetadataChange
 
-        file_ = FileStorage(io.BytesIO(b'abc'), 'filename-éàè.txt')
+        file_ = FileStorage(io.BytesIO(b"abc"), "filename-éàè.txt")
         addition = FileAddition(file_)
-        change = MetadataChange('key', 'value')
+        change = MetadataChange("key", "value")
         delete = FileDeletion()
 
         # File addition
-        raw_file_processor(self.tempdir, 'music', 'id1', '.mp3', [addition])
-        path = os.path.join(self.tempdir, 'music', 'id1.mp3')
+        raw_file_processor(self.tempdir, "music", "id1", ".mp3", [addition])
+        path = os.path.join(self.tempdir, "music", "id1.mp3")
         self.assertTrue(os.path.isfile(path))
         with open(path) as f:
-            self.assertEqual(f.read(), 'abc')
+            self.assertEqual(f.read(), "abc")
 
         # File change (nothing happens) and deletion
-        raw_file_processor(self.tempdir, 'music', 'id1', '.mp3', [change])
-        raw_file_processor(self.tempdir, 'music', 'id1', '.mp3', [delete])
+        raw_file_processor(self.tempdir, "music", "id1", ".mp3", [change])
+        raw_file_processor(self.tempdir, "music", "id1", ".mp3", [delete])
         self.assertTrue(not os.path.isfile(path))
 
         # Invalid change (not found)
-        self.assertRaises(NotFound, raw_file_processor,
-                          self.tempdir, 'music', 'id1', '.mp3', [change])
+        self.assertRaises(
+            NotFound, raw_file_processor, self.tempdir, "music", "id1", ".mp3", [change]
+        )
 
         # Invalid deletion (not found)
-        self.assertRaises(NotFound, raw_file_processor,
-                          self.tempdir, 'music', 'id1', '.mp3', [delete])
+        self.assertRaises(
+            NotFound, raw_file_processor, self.tempdir, "music", "id1", ".mp3", [delete]
+        )
 
         # Completely invalid change
-        self.assertRaises(ValueError, raw_file_processor,
-                          self.tempdir, 'music', 'id1', '.mp3', ['invalid'])
+        self.assertRaises(
+            ValueError,
+            raw_file_processor,
+            self.tempdir,
+            "music",
+            "id1",
+            ".mp3",
+            ["invalid"],
+        )
 
     def testIndexProcessor(self):
         from klangbecken import index_processor
         from klangbecken import FileAddition, FileDeletion, MetadataChange
 
-        index_path = os.path.join(self.tempdir, 'index.json')
+        index_path = os.path.join(self.tempdir, "index.json")
 
         # Add two new files
-        file_ = FileStorage(io.BytesIO(b'abc'), 'filename.txt')
-        index_processor(self.tempdir, 'music', 'fileId1', '.mp3',
-                        [FileAddition(file_)])
-        index_processor(self.tempdir, 'music', 'fileId2', '.ogg',
-                        [FileAddition(file_)])
+        file_ = FileStorage(io.BytesIO(b"abc"), "filename.txt")
+        index_processor(self.tempdir, "music", "fileId1", ".mp3", [FileAddition(file_)])
+        index_processor(self.tempdir, "music", "fileId2", ".ogg", [FileAddition(file_)])
 
         with open(index_path) as f:
             data = json.load(f)
 
-        self.assertTrue('fileId1' in data)
-        self.assertTrue('fileId2' in data)
+        self.assertTrue("fileId1" in data)
+        self.assertTrue("fileId2" in data)
 
         # Set some initial metadata
-        index_processor(self.tempdir, 'music', 'fileId1', '.mp3',
-                        [MetadataChange('key1', 'value1')])
-        index_processor(self.tempdir, 'music', 'fileId2', '.ogg',
-                        [MetadataChange('key1', 'value1'),
-                         MetadataChange('key2', 'value2')])
+        index_processor(
+            self.tempdir, "music", "fileId1", ".mp3", [MetadataChange("key1", "value1")]
+        )
+        index_processor(
+            self.tempdir,
+            "music",
+            "fileId2",
+            ".ogg",
+            [MetadataChange("key1", "value1"), MetadataChange("key2", "value2")],
+        )
 
         with open(index_path) as f:
             data = json.load(f)
 
-        self.assertTrue('key1' in data['fileId1'])
-        self.assertEqual(data['fileId1']['key1'], 'value1')
-        self.assertTrue('key1' in data['fileId2'])
-        self.assertEqual(data['fileId2']['key1'], 'value1')
-        self.assertTrue('key2' in data['fileId2'])
-        self.assertEqual(data['fileId2']['key2'], 'value2')
+        self.assertTrue("key1" in data["fileId1"])
+        self.assertEqual(data["fileId1"]["key1"], "value1")
+        self.assertTrue("key1" in data["fileId2"])
+        self.assertEqual(data["fileId2"]["key1"], "value1")
+        self.assertTrue("key2" in data["fileId2"])
+        self.assertEqual(data["fileId2"]["key2"], "value2")
 
         # Modify metadata
-        index_processor(self.tempdir, 'music', 'fileId1', '.mp3',
-                        [MetadataChange('key1', 'value1-1'),
-                         MetadataChange('key2', 'value2-1')])
-        index_processor(self.tempdir, 'music', 'fileId2', '.ogg',
-                        [MetadataChange('key2', 'value2-1-œ')])
+        index_processor(
+            self.tempdir,
+            "music",
+            "fileId1",
+            ".mp3",
+            [MetadataChange("key1", "value1-1"), MetadataChange("key2", "value2-1")],
+        )
+        index_processor(
+            self.tempdir,
+            "music",
+            "fileId2",
+            ".ogg",
+            [MetadataChange("key2", "value2-1-œ")],
+        )
 
         with open(index_path) as f:
             data = json.load(f)
 
-        self.assertTrue('key1' in data['fileId1'])
-        self.assertEqual(data['fileId1']['key1'], 'value1-1')
-        self.assertTrue('key2' in data['fileId1'])
-        self.assertEqual(data['fileId1']['key2'], 'value2-1')
-        self.assertTrue('key1' in data['fileId2'])
-        self.assertEqual(data['fileId2']['key1'], 'value1')
-        self.assertTrue('key2' in data['fileId2'])
-        self.assertEqual(data['fileId2']['key2'], 'value2-1-œ')
+        self.assertTrue("key1" in data["fileId1"])
+        self.assertEqual(data["fileId1"]["key1"], "value1-1")
+        self.assertTrue("key2" in data["fileId1"])
+        self.assertEqual(data["fileId1"]["key2"], "value2-1")
+        self.assertTrue("key1" in data["fileId2"])
+        self.assertEqual(data["fileId2"]["key1"], "value1")
+        self.assertTrue("key2" in data["fileId2"])
+        self.assertEqual(data["fileId2"]["key2"], "value2-1-œ")
 
         # Delete one file
-        index_processor(self.tempdir, 'music', 'fileId1', '.mp3',
-                        [FileDeletion()])
+        index_processor(self.tempdir, "music", "fileId1", ".mp3", [FileDeletion()])
 
         with open(index_path) as f:
             data = json.load(f)
 
-        self.assertTrue('fileId1' not in data)
-        self.assertTrue('fileId2' in data)
+        self.assertTrue("fileId1" not in data)
+        self.assertTrue("fileId2" in data)
 
         # Try duplicating file ids
-        with self.assertRaisesRegex(UnprocessableEntity, 'Duplicate'):
-            index_processor(self.tempdir, 'music', 'fileId2', '.ogg',
-                            [FileAddition(file_)])
-        with self.assertRaisesRegex(UnprocessableEntity, 'Duplicate'):
-            index_processor(self.tempdir, 'jingles', 'fileId2', '.mp3',
-                            [FileAddition(file_)])
-        with self.assertRaisesRegex(UnprocessableEntity, 'Duplicate'):
-            index_processor(self.tempdir, 'music', 'fileId2', '.mp3',
-                            [FileAddition(file_)])
+        with self.assertRaisesRegex(UnprocessableEntity, "Duplicate"):
+            index_processor(
+                self.tempdir, "music", "fileId2", ".ogg", [FileAddition(file_)]
+            )
+        with self.assertRaisesRegex(UnprocessableEntity, "Duplicate"):
+            index_processor(
+                self.tempdir, "jingles", "fileId2", ".mp3", [FileAddition(file_)]
+            )
+        with self.assertRaisesRegex(UnprocessableEntity, "Duplicate"):
+            index_processor(
+                self.tempdir, "music", "fileId2", ".mp3", [FileAddition(file_)]
+            )
 
         # Try modifying non existent files
         with self.assertRaises(NotFound):
-            index_processor(self.tempdir, 'music', 'fileIdXY', '.ogg',
-                            [MetadataChange('key', 'val')])
+            index_processor(
+                self.tempdir,
+                "music",
+                "fileIdXY",
+                ".ogg",
+                [MetadataChange("key", "val")],
+            )
 
         # Try deleting non existent file ids
         with self.assertRaises(NotFound):
-            index_processor(self.tempdir, 'music', 'fileIdXY', '.ogg',
-                            [FileDeletion()])
+            index_processor(self.tempdir, "music", "fileIdXY", ".ogg", [FileDeletion()])
 
         with open(index_path) as f:
             data = json.load(f)
-        self.assertTrue('fileId2' in data)
-        self.assertTrue('fileXY' not in data)
+        self.assertTrue("fileId2" in data)
+        self.assertTrue("fileXY" not in data)
 
         # Completely invalid change
-        self.assertRaises(ValueError, index_processor,
-                          self.tempdir, 'music', 'id1', '.mp3', ['invalid'])
+        self.assertRaises(
+            ValueError,
+            index_processor,
+            self.tempdir,
+            "music",
+            "id1",
+            ".mp3",
+            ["invalid"],
+        )
 
     def testFileTagProcessor(self):
         from klangbecken import file_tag_processor
@@ -717,123 +727,140 @@ class ProcessorsTestCase(unittest.TestCase):
         from mutagen import File
 
         # No-ops
-        file_tag_processor(self.tempdir, 'nonexistant', 'fileIdZZ', '.mp3', [
-            FileAddition(''),
-            MetadataChange('id', 'abc'),
-            MetadataChange('playlist', 'abc'),
-            MetadataChange('ext', 'abc'),
-            MetadataChange('length', 'abc'),
-            MetadataChange('nonexistant', 'abc'),
-            FileDeletion(),
-        ])
+        file_tag_processor(
+            self.tempdir,
+            "nonexistant",
+            "fileIdZZ",
+            ".mp3",
+            [
+                FileAddition(""),
+                MetadataChange("id", "abc"),
+                MetadataChange("playlist", "abc"),
+                MetadataChange("ext", "abc"),
+                MetadataChange("length", "abc"),
+                MetadataChange("nonexistant", "abc"),
+                FileDeletion(),
+            ],
+        )
 
         changes = {
-            'artist': 'New Artist (๛)',
-            'title': 'New Title (᛭)',
-            'album': 'New Album (٭)',
-            'cue_in': '0.123',
-            'cue_out': '123',
-            'track_gain': '-12 dB',
+            "artist": "New Artist (๛)",
+            "title": "New Title (᛭)",
+            "album": "New Album (٭)",
+            "cue_in": "0.123",
+            "cue_out": "123",
+            "track_gain": "-12 dB",
         }
-        metadata_changes = [MetadataChange(key, val) for key, val
-                            in changes.items()]
+        metadata_changes = [MetadataChange(key, val) for key, val in changes.items()]
 
         # Valid files
-        for filename in ['silence.mp3', 'silence-stripped.mp3', 'silence.ogg',
-                         'silence.flac']:
-            prefix, ext = filename.split('.')
+        for filename in [
+            "silence.mp3",
+            "silence-stripped.mp3",
+            "silence.ogg",
+            "silence.flac",
+        ]:
+            prefix, ext = filename.split(".")
 
-            path = os.path.join(self.tempdir, 'music', filename)
+            path = os.path.join(self.tempdir, "music", filename)
             mutagenfile = File(path, easy=True)
 
             # Make sure tags are not already the same before updating
             for key, val in changes.items():
-                self.assertNotEqual(val, mutagenfile.get(key, [''])[0])
+                self.assertNotEqual(val, mutagenfile.get(key, [""])[0])
 
             # Update and verify tags
-            file_tag_processor(self.tempdir, 'music', prefix, '.' + ext,
-                               metadata_changes)
+            file_tag_processor(
+                self.tempdir, "music", prefix, "." + ext, metadata_changes
+            )
             mutagenfile = File(path, easy=True)
             for key, val in changes.items():
-                self.assertEqual(len(mutagenfile.get(key, [''])), 1)
-                self.assertEqual(val, mutagenfile.get(key, [''])[0])
+                self.assertEqual(len(mutagenfile.get(key, [""])), 1)
+                self.assertEqual(val, mutagenfile.get(key, [""])[0])
 
     def testPlaylistProcessor(self):
         from klangbecken import playlist_processor
         from klangbecken import FileDeletion, MetadataChange
 
-        music_path = os.path.join(self.tempdir, 'music.m3u')
-        jingles_path = os.path.join(self.tempdir, 'jingles.m3u')
+        music_path = os.path.join(self.tempdir, "music.m3u")
+        jingles_path = os.path.join(self.tempdir, "jingles.m3u")
 
         # Update playlist weight (initial)
-        playlist_processor(self.tempdir, 'music', 'fileId1', '.mp3',
-                           [MetadataChange('weight', 2)])
+        playlist_processor(
+            self.tempdir, "music", "fileId1", ".mp3", [MetadataChange("weight", 2)]
+        )
 
         with open(music_path) as f:
-            lines = f.read().split('\n')
-        entries = [ln for ln in lines if ln.endswith('music/fileId1.mp3')]
+            lines = f.read().split("\n")
+        entries = [ln for ln in lines if ln.endswith("music/fileId1.mp3")]
         self.assertEqual(len(entries), 2)
 
         with open(jingles_path) as f:
             data = f.read()
-        self.assertEqual(data, '')
+        self.assertEqual(data, "")
 
         # Update playlist weight
-        playlist_processor(self.tempdir, 'music', 'fileId1', '.mp3',
-                           [MetadataChange('weight', 4)])
+        playlist_processor(
+            self.tempdir, "music", "fileId1", ".mp3", [MetadataChange("weight", 4)]
+        )
 
         with open(music_path) as f:
-            lines = f.read().split('\n')
-        entries = [ln for ln in lines if ln.endswith('music/fileId1.mp3')]
+            lines = f.read().split("\n")
+        entries = [ln for ln in lines if ln.endswith("music/fileId1.mp3")]
         self.assertEqual(len(entries), 4)
 
         with open(jingles_path) as f:
             data = f.read()
-        self.assertEqual(data, '')
+        self.assertEqual(data, "")
 
         # Set playlist weight to zero (same as delete)
-        playlist_processor(self.tempdir, 'music', 'fileId1', '.mp3',
-                           [MetadataChange('weight', 0)])
+        playlist_processor(
+            self.tempdir, "music", "fileId1", ".mp3", [MetadataChange("weight", 0)]
+        )
 
         with open(music_path) as f:
             data = f.read()
-        self.assertEqual(data, '')
+        self.assertEqual(data, "")
 
         with open(jingles_path) as f:
             data = f.read()
-        self.assertEqual(data, '')
+        self.assertEqual(data, "")
 
         # Add more files to playlist
-        playlist_processor(self.tempdir, 'music', 'fileId1', '.mp3',
-                           [MetadataChange('weight', 2)])
-        playlist_processor(self.tempdir, 'music', 'fileId2', '.ogg',
-                           [MetadataChange('weight', 1)])
-        playlist_processor(self.tempdir, 'music', 'fileId3', '.flac',
-                           [MetadataChange('weight', 3)])
-        playlist_processor(self.tempdir, 'jingles', 'fileId4', '.mp3',
-                           [MetadataChange('weight', 2)])
-        playlist_processor(self.tempdir, 'jingles', 'fileId5', '.mp3',
-                           [MetadataChange('weight', 3)])
+        playlist_processor(
+            self.tempdir, "music", "fileId1", ".mp3", [MetadataChange("weight", 2)]
+        )
+        playlist_processor(
+            self.tempdir, "music", "fileId2", ".ogg", [MetadataChange("weight", 1)]
+        )
+        playlist_processor(
+            self.tempdir, "music", "fileId3", ".flac", [MetadataChange("weight", 3)]
+        )
+        playlist_processor(
+            self.tempdir, "jingles", "fileId4", ".mp3", [MetadataChange("weight", 2)]
+        )
+        playlist_processor(
+            self.tempdir, "jingles", "fileId5", ".mp3", [MetadataChange("weight", 3)]
+        )
 
         with open(music_path) as f:
             lines = [ln.strip() for ln in f.readlines()]
-        entries = [ln for ln in lines if ln.endswith('music/fileId1.mp3')]
+        entries = [ln for ln in lines if ln.endswith("music/fileId1.mp3")]
         self.assertEqual(len(entries), 2)
-        entries = [ln for ln in lines if ln.endswith('music/fileId2.ogg')]
+        entries = [ln for ln in lines if ln.endswith("music/fileId2.ogg")]
         self.assertEqual(len(entries), 1)
-        entries = [ln for ln in lines if ln.endswith('music/fileId3.flac')]
+        entries = [ln for ln in lines if ln.endswith("music/fileId3.flac")]
         self.assertEqual(len(entries), 3)
 
         with open(jingles_path) as f:
             lines = [ln.strip() for ln in f.readlines()]
-        entries = [ln for ln in lines if ln.endswith('jingles/fileId4.mp3')]
+        entries = [ln for ln in lines if ln.endswith("jingles/fileId4.mp3")]
         self.assertEqual(len(entries), 2)
-        entries = [ln for ln in lines if ln.endswith('jingles/fileId5.mp3')]
+        entries = [ln for ln in lines if ln.endswith("jingles/fileId5.mp3")]
         self.assertEqual(len(entries), 3)
 
         # Delete non existing file (must be possible)
-        playlist_processor(self.tempdir, 'music', 'fileIdXY', '.ogg',
-                           [FileDeletion()])
+        playlist_processor(self.tempdir, "music", "fileIdXY", ".ogg", [FileDeletion()])
         with open(music_path) as f:
             lines = [ln.strip() for ln in f.readlines()]
         self.assertEqual(len(lines), 6)
@@ -845,13 +872,12 @@ class ProcessorsTestCase(unittest.TestCase):
         self.assertTrue(all(lines))
 
         # Delete existing file
-        playlist_processor(self.tempdir, 'music', 'fileId1', '.mp3',
-                           [FileDeletion()])
+        playlist_processor(self.tempdir, "music", "fileId1", ".mp3", [FileDeletion()])
         with open(music_path) as f:
             lines = [ln.strip() for ln in f.readlines()]
         self.assertEqual(len(lines), 4)
         self.assertTrue(all(lines))
-        entries = [ln for ln in lines if ln.endswith('music/fileId1.mp3')]
+        entries = [ln for ln in lines if ln.endswith("music/fileId1.mp3")]
         self.assertListEqual(entries, [])
 
         with open(jingles_path) as f:
@@ -860,26 +886,23 @@ class ProcessorsTestCase(unittest.TestCase):
         self.assertTrue(all(lines))
 
         # Multiple deletes
-        playlist_processor(self.tempdir, 'music', 'fileId3', '.flac',
-                           [FileDeletion()])
-        playlist_processor(self.tempdir, 'jingles', 'fileId4', '.mp3',
-                           [FileDeletion()])
-        playlist_processor(self.tempdir, 'jingles', 'fileId5', '.mp3',
-                           [FileDeletion()])
+        playlist_processor(self.tempdir, "music", "fileId3", ".flac", [FileDeletion()])
+        playlist_processor(self.tempdir, "jingles", "fileId4", ".mp3", [FileDeletion()])
+        playlist_processor(self.tempdir, "jingles", "fileId5", ".mp3", [FileDeletion()])
 
         with open(music_path) as f:
             lines = [ln.strip() for ln in f.readlines()]
         self.assertEqual(len(lines), 1)
-        self.assertTrue(lines[0].endswith('music/fileId2.ogg'))
+        self.assertTrue(lines[0].endswith("music/fileId2.ogg"))
 
         with open(jingles_path) as f:
             data = f.read()
-        self.assertEqual(data, '')
+        self.assertEqual(data, "")
 
     def testPlaynextProcessor(self):
         from klangbecken import playnext_processor
 
-        prio_path = os.path.join(self.tempdir, 'prio.m3u')
+        prio_path = os.path.join(self.tempdir, "prio.m3u")
 
         # Invalid playnext updates
         with self.assertRaises(UnprocessableEntity):
@@ -887,14 +910,14 @@ class ProcessorsTestCase(unittest.TestCase):
         with self.assertRaises(UnprocessableEntity):
             playnext_processor(self.tempdir, {})
         with self.assertRaises(UnprocessableEntity):
-            playnext_processor(self.tempdir, {'file': 'funny/../path.mp3'})
+            playnext_processor(self.tempdir, {"file": "funny/../path.mp3"})
 
         # Inexistent file
         with self.assertRaises(NotFound):
-            playnext_processor(self.tempdir, {'file': 'music/nonexistent.mp3'})
+            playnext_processor(self.tempdir, {"file": "music/nonexistent.mp3"})
 
         # Correct update
-        playnext_processor(self.tempdir, {'file': 'music/silence.mp3'})
+        playnext_processor(self.tempdir, {"file": "music/silence.mp3"})
         with open(prio_path) as f:
             data = f.read()
-        self.assertEqual(data.strip(), 'music/silence.mp3')
+        self.assertEqual(data.strip(), "music/silence.mp3")

--- a/tests/test_devserver.py
+++ b/tests/test_devserver.py
@@ -23,28 +23,31 @@ class StandaloneWebApplicationStartupTestCase(unittest.TestCase):
         from klangbecken import StandaloneWebApplication, init_cmd
 
         init_cmd(self.tempdir)
-        with capture(StandaloneWebApplication, self.tempdir, 'secret') \
-                as (out, err, ret):
+        with capture(StandaloneWebApplication, self.tempdir, "secret") as (
+            out,
+            err,
+            ret,
+        ):
             self.assertNotIn("WARNING", out)
 
     def testDirStructure(self):
         from klangbecken import StandaloneWebApplication, init_cmd
-        self.assertFalse(os.path.isdir(os.path.join(self.tempdir, 'music')))
+
+        self.assertFalse(os.path.isdir(os.path.join(self.tempdir, "music")))
 
         with self.assertRaises(Exception):
-            StandaloneWebApplication(self.tempdir, 'secret')
+            StandaloneWebApplication(self.tempdir, "secret")
 
         init_cmd(self.tempdir)
-        StandaloneWebApplication(self.tempdir, 'secret')
-        self.assertTrue(os.path.isdir(os.path.join(self.tempdir, 'music')))
+        StandaloneWebApplication(self.tempdir, "secret")
+        self.assertTrue(os.path.isdir(os.path.join(self.tempdir, "music")))
 
-        with open(os.path.join(self.tempdir, 'music', 'abc.txt'), 'w'):
+        with open(os.path.join(self.tempdir, "music", "abc.txt"), "w"):
             pass
 
-        StandaloneWebApplication(self.tempdir, 'secret')
-        self.assertTrue(os.path.isdir(os.path.join(self.tempdir, 'music')))
-        self.assertTrue(os.path.isfile(os.path.join(self.tempdir, 'music',
-                                                    'abc.txt')))
+        StandaloneWebApplication(self.tempdir, "secret")
+        self.assertTrue(os.path.isdir(os.path.join(self.tempdir, "music")))
+        self.assertTrue(os.path.isfile(os.path.join(self.tempdir, "music", "abc.txt")))
 
 
 class StandaloneWebApplicationTestCase(unittest.TestCase):
@@ -54,95 +57,96 @@ class StandaloneWebApplicationTestCase(unittest.TestCase):
         self.current_path = os.path.dirname(os.path.realpath(__file__))
         self.tempdir = tempfile.mkdtemp()
         init_cmd(self.tempdir)
-        app = StandaloneWebApplication(self.tempdir, 'secret')
+        app = StandaloneWebApplication(self.tempdir, "secret")
         self.client = Client(app, BaseResponse)
 
     def tearDown(self):
         shutil.rmtree(self.tempdir)
 
     def testIndexHtml(self):
-        resp = self.client.get('/')
+        resp = self.client.get("/")
         self.assertEqual(resp.status_code, 200)
-        self.assertTrue(resp.data.startswith(b'Welcome'))
-        self.assertIn(b'Klangbecken', resp.data)
+        self.assertTrue(resp.data.startswith(b"Welcome"))
+        self.assertIn(b"Klangbecken", resp.data)
         resp.close()
 
     def testApi(self):
         # Login
-        resp = self.client.post('/api/auth/login/')
+        resp = self.client.post("/api/auth/login/")
         self.assertEqual(resp.status_code, 200)
         data = json.loads(resp.data)
-        self.assertIn('token', data)
-        token = data['token']
+        self.assertIn("token", data)
+        token = data["token"]
         resp.close()
 
         # Upload
-        path = os.path.join(self.current_path, 'audio',
-                            'silence-unicode-jointstereo.mp3')
-        with open(path, 'rb') as f:
+        path = os.path.join(
+            self.current_path, "audio", "silence-unicode-jointstereo.mp3"
+        )
+        with open(path, "rb") as f:
             resp = self.client.post(
-                '/api/music/',
-                data={'file': (f, 'silence-unicode-jointstereo.mp3')},
-                headers=[('Authorization', f'Bearer {token}')]
+                "/api/music/",
+                data={"file": (f, "silence-unicode-jointstereo.mp3")},
+                headers=[("Authorization", f"Bearer {token}")],
             )
         self.assertEqual(resp.status_code, 200)
         data = json.loads(resp.data)
         fileId = list(data.keys())[0]
         self.assertEqual(fileId, str(uuid.UUID(fileId)))
         expected = {
-            'original_filename': 'silence-unicode-jointstereo.mp3',
-            'length': 1.0,
-            'album': '☀⚛♬',
-            'title': 'ÄÖÜ',
-            'artist': 'ÀÉÈ',
-            'ext': '.mp3',
-            'weight': 1,
-            'playlist': 'music',
-            'id': fileId
+            "original_filename": "silence-unicode-jointstereo.mp3",
+            "length": 1.0,
+            "album": "☀⚛♬",
+            "title": "ÄÖÜ",
+            "artist": "ÀÉÈ",
+            "ext": ".mp3",
+            "weight": 1,
+            "playlist": "music",
+            "id": fileId,
         }
         self.assertLessEqual(set(expected.items()), set(data[fileId].items()))
         resp.close()
 
         # Update
         resp = self.client.put(
-            '/api/music/' + fileId + '.mp3',
-            data=json.dumps({'weight': 4}),
-            content_type='text/json',
-            headers=[('Authorization', f'Bearer {token}')]
+            "/api/music/" + fileId + ".mp3",
+            data=json.dumps({"weight": 4}),
+            content_type="text/json",
+            headers=[("Authorization", f"Bearer {token}")],
         )
         self.assertEqual(resp.status_code, 200)
         resp.close()
 
         # Get file
-        resp = self.client.get('/data/music/' + fileId + '.mp3')
+        resp = self.client.get("/data/music/" + fileId + ".mp3")
         self.assertEqual(resp.status_code, 200)
         resp.close()
 
         # Put file in prio list
         resp = self.client.post(
-            '/api/playnext/',
-            data=json.dumps({'file': 'music/' + fileId + '.mp3'}),
-            content_type='text/json',
-            headers=[('Authorization', f'Bearer {token}')]
+            "/api/playnext/",
+            data=json.dumps({"file": "music/" + fileId + ".mp3"}),
+            content_type="text/json",
+            headers=[("Authorization", f"Bearer {token}")],
         )
         self.assertEqual(resp.status_code, 200)
         resp.close()
 
         # Get index.json
-        resp = self.client.get('/data/index.json')
+        resp = self.client.get("/data/index.json")
         self.assertEqual(resp.status_code, 200)
         resp.close()
 
         # Delete file
         resp = self.client.delete(
-            '/api/music/' + fileId + '.mp3',
-            headers=[('Authorization', f'Bearer {token}')]
+            "/api/music/" + fileId + ".mp3",
+            headers=[("Authorization", f"Bearer {token}")],
         )
         self.assertEqual(resp.status_code, 200)
         resp.close()
 
         # Verify that we are logged out
-        resp = self.client.post('/api/music/')
+        resp = self.client.post("/api/music/")
         self.assertEqual(resp.status_code, 401)
         resp.close()
 
@@ -158,38 +162,39 @@ class DataDirCreatorTestCase(unittest.TestCase):
     def testDataDirCheckOnly(self):
         from klangbecken import _check_data_dir, PLAYLISTS
 
-        for playlist in PLAYLISTS + ('prio',):
+        for playlist in PLAYLISTS + ("prio",):
             path = os.path.join(self.tempdir, playlist)
             with self.assertRaises(Exception):
                 _check_data_dir(self.tempdir, False)
             os.mkdir(path)
 
-        for playlist in PLAYLISTS + ('prio',):
-            path = os.path.join(self.tempdir, playlist + '.m3u')
+        for playlist in PLAYLISTS + ("prio",):
+            path = os.path.join(self.tempdir, playlist + ".m3u")
             with self.assertRaises(Exception):
                 _check_data_dir(self.tempdir, False)
-            with open(path, 'a'):
+            with open(path, "a"):
                 pass
         with self.assertRaises(Exception):
             _check_data_dir(self.tempdir, False)
 
-        with open(os.path.join(self.tempdir, 'index.json'), 'w'):
+        with open(os.path.join(self.tempdir, "index.json"), "w"):
             pass
 
-        os.mkdir(os.path.join(self.tempdir, 'log'))
+        os.mkdir(os.path.join(self.tempdir, "log"))
 
         _check_data_dir(self.tempdir, False)
 
     def testDataDirCreation(self):
         from klangbecken import _check_data_dir, PLAYLISTS
+
         _check_data_dir(self.tempdir, create=True)
         for playlist in PLAYLISTS:
             path = os.path.join(self.tempdir, playlist)
             self.assertTrue(os.path.isdir(path))
-            path += '.m3u'
+            path += ".m3u"
             self.assertTrue(os.path.isfile(path))
 
-        path = os.path.join(self.tempdir, 'index.json')
+        path = os.path.join(self.tempdir, "index.json")
         self.assertTrue(os.path.isfile(path))
         with open(path) as f:
             self.assertEqual(json.load(f), {})

--- a/tests/test_fsck.py
+++ b/tests/test_fsck.py
@@ -11,22 +11,25 @@ from .utils import capture
 class FsckTestCase(unittest.TestCase):
     def setUp(self):
         from klangbecken import _check_data_dir, import_cmd
+
         self.current_path = os.path.dirname(os.path.realpath(__file__))
         self.tempdir = tempfile.mkdtemp()
-        self.jingles_dir = os.path.join(self.tempdir, 'jingles')
+        self.jingles_dir = os.path.join(self.tempdir, "jingles")
         _check_data_dir(self.tempdir, create=True)
 
         # Correctly import a couple of files
-        files = [os.path.join(self.current_path, 'audio', 'padded' + ext)
-                 for ext in '.ogg .flac -stereo.mp3'.split()]
+        files = [
+            os.path.join(self.current_path, "audio", "padded" + ext)
+            for ext in ".ogg .flac -stereo.mp3".split()
+        ]
         try:
-            args = [self.tempdir, 'jingles', files, True]
+            args = [self.tempdir, "jingles", files, True]
             with capture(import_cmd, *args) as (out, err, ret):
                 pass
         except SystemExit as e:
             if e.code != 0:
                 print(err, file=sys.stderr)
-                raise(RuntimeError('Command execution failed'))
+                raise (RuntimeError("Command execution failed"))
 
     def tearDown(self):
         shutil.rmtree(self.tempdir)
@@ -35,22 +38,22 @@ class FsckTestCase(unittest.TestCase):
         from klangbecken import main, import_cmd
 
         # Correctly import a couple of files
-        file_path = os.path.join(self.current_path, 'audio', 'padded.ogg')
+        file_path = os.path.join(self.current_path, "audio", "padded.ogg")
         try:
-            args = [self.tempdir, 'music', [file_path], True]
+            args = [self.tempdir, "music", [file_path], True]
             with capture(import_cmd, *args) as (out, err, ret):
                 pass
         except SystemExit as e:
             if e.code != 0:
                 print(err, file=sys.stderr)
-                raise(RuntimeError('Command execution failed'))
-        argv, sys.argv = sys.argv, ['', 'fsck', '-d', self.tempdir]
+                raise (RuntimeError("Command execution failed"))
+        argv, sys.argv = sys.argv, ["", "fsck", "-d", self.tempdir]
         try:
             with self.assertRaises(SystemExit) as cm:
                 with capture(main) as (out, err, ret):
-                    self.assertIn('ERROR', err)
-                    self.assertIn('WARNING', err)
-                    self.assertIn('very short', err)
+                    self.assertIn("ERROR", err)
+                    self.assertIn("WARNING", err)
+                    self.assertIn("very short", err)
             self.assertEqual(cm.exception.code, 1)
         finally:
             sys.arv = argv
@@ -58,15 +61,15 @@ class FsckTestCase(unittest.TestCase):
     def testFsckCorruptIndexJson(self):
         from klangbecken import main
 
-        index_path = os.path.join(self.tempdir, 'index.json')
-        with open(index_path, 'w'):
+        index_path = os.path.join(self.tempdir, "index.json")
+        with open(index_path, "w"):
             pass
 
-        argv, sys.argv = sys.argv, ['', 'fsck', '-d', self.tempdir]
+        argv, sys.argv = sys.argv, ["", "fsck", "-d", self.tempdir]
         try:
             with self.assertRaises(SystemExit) as cm:
                 with capture(main) as (out, err, ret):
-                    self.assertIn('ERROR', err)
+                    self.assertIn("ERROR", err)
             self.assertEqual(cm.exception.code, 1)
         finally:
             sys.arv = argv
@@ -76,25 +79,25 @@ class FsckTestCase(unittest.TestCase):
 
         shutil.rmtree(self.jingles_dir)
 
-        argv, sys.argv = sys.argv, ['', 'fsck', '-d', self.tempdir]
+        argv, sys.argv = sys.argv, ["", "fsck", "-d", self.tempdir]
         try:
             with self.assertRaises(SystemExit) as cm:
                 with capture(main) as (out, err, ret):
-                    self.assertIn('ERROR', err)
+                    self.assertIn("ERROR", err)
             self.assertEqual(cm.exception.code, 1)
         finally:
             sys.arv = argv
 
     def testFsck(self):
         from klangbecken import main
-        argv, sys.argv = sys.argv, ['', 'fsck', '-d', 'invalid']
+
+        argv, sys.argv = sys.argv, ["", "fsck", "-d", "invalid"]
         try:
             # inexistent data_dir
             with self.assertRaises(SystemExit) as cm:
                 with capture(main) as (out, err, ret):
-                    self.assertIn('ERROR', err)
-                    self.assertIn("Data directory 'invalid' does not exist",
-                                  err)
+                    self.assertIn("ERROR", err)
+                    self.assertIn("Data directory 'invalid' does not exist", err)
             self.assertEqual(cm.exception.code, 1)
 
             sys.argv[-1] = self.tempdir
@@ -102,156 +105,161 @@ class FsckTestCase(unittest.TestCase):
             # correct invocation
             with self.assertRaises(SystemExit) as cm:
                 with capture(main) as (out, err, ret):
-                    self.assertEqual(err.strip(), '')
+                    self.assertEqual(err.strip(), "")
             self.assertEqual(cm.exception.code, 0)
         finally:
             sys.arv = argv
 
     def testIndexWithWrongId(self):
         from klangbecken import main
-        argv, sys.argv = sys.argv, ['', 'fsck', '-d', self.tempdir]
 
-        index_path = os.path.join(self.tempdir, 'index.json')
+        argv, sys.argv = sys.argv, ["", "fsck", "-d", self.tempdir]
+
+        index_path = os.path.join(self.tempdir, "index.json")
         with open(index_path) as f:
             data = json.load(f)
 
         entry1, entry2 = list(data.values())[:2]
-        entry1['id'], entry2['id'] = entry2['id'], entry1['id']
-        with open(index_path, 'w') as f:
+        entry1["id"], entry2["id"] = entry2["id"], entry1["id"]
+        with open(index_path, "w") as f:
             json.dump(data, f)
 
         try:
             with self.assertRaises(SystemExit) as cm:
                 with capture(main) as (out, err, ret):
-                    self.assertIn('ERROR', err)
-                    self.assertIn('Id missmatch', err)
+                    self.assertIn("ERROR", err)
+                    self.assertIn("Id missmatch", err)
             self.assertEqual(cm.exception.code, 1)
         finally:
             sys.arv = argv
 
     def testIndexWithWrongCueIn(self):
         from klangbecken import main
-        argv, sys.argv = sys.argv, ['', 'fsck', '-d', self.tempdir]
 
-        index_path = os.path.join(self.tempdir, 'index.json')
+        argv, sys.argv = sys.argv, ["", "fsck", "-d", self.tempdir]
+
+        index_path = os.path.join(self.tempdir, "index.json")
         with open(index_path) as f:
             data = json.load(f)
 
         entry = next(iter(data.values()))
-        entry['cue_in'], entry['cue_out'] = entry['cue_out'], entry['cue_in']
+        entry["cue_in"], entry["cue_out"] = entry["cue_out"], entry["cue_in"]
 
-        with open(index_path, 'w') as f:
+        with open(index_path, "w") as f:
             json.dump(data, f)
 
         try:
             with self.assertRaises(SystemExit) as cm:
                 with capture(main) as (out, err, ret):
-                    self.assertIn('ERROR', err)
-                    self.assertIn('cue_in larger than cue_out', err)
+                    self.assertIn("ERROR", err)
+                    self.assertIn("cue_in larger than cue_out", err)
             self.assertEqual(cm.exception.code, 1)
         finally:
             sys.arv = argv
 
     def testIndexWithWrongCueOut(self):
         from klangbecken import main
-        argv, sys.argv = sys.argv, ['', 'fsck', '-d', self.tempdir]
 
-        index_path = os.path.join(self.tempdir, 'index.json')
+        argv, sys.argv = sys.argv, ["", "fsck", "-d", self.tempdir]
+
+        index_path = os.path.join(self.tempdir, "index.json")
         with open(index_path) as f:
             data = json.load(f)
 
         entry = next(iter(data.values()))
-        entry['cue_out'], entry['length'] = entry['length'], entry['cue_out']
+        entry["cue_out"], entry["length"] = entry["length"], entry["cue_out"]
 
-        with open(index_path, 'w') as f:
+        with open(index_path, "w") as f:
             json.dump(data, f)
 
         try:
             with self.assertRaises(SystemExit) as cm:
                 with capture(main) as (out, err, ret):
-                    self.assertIn('ERROR', err)
-                    self.assertIn('cue_out larger than length', err)
+                    self.assertIn("ERROR", err)
+                    self.assertIn("cue_out larger than length", err)
             self.assertEqual(cm.exception.code, 1)
         finally:
             sys.arv = argv
 
     def testIndexMissingEntries(self):
         from klangbecken import main
-        argv, sys.argv = sys.argv, ['', 'fsck', '-d', self.tempdir]
 
-        index_path = os.path.join(self.tempdir, 'index.json')
+        argv, sys.argv = sys.argv, ["", "fsck", "-d", self.tempdir]
+
+        index_path = os.path.join(self.tempdir, "index.json")
         with open(index_path) as f:
             data = json.load(f)
 
         entry = next(iter(data.values()))
-        del entry['cue_out']
+        del entry["cue_out"]
 
-        with open(index_path, 'w') as f:
+        with open(index_path, "w") as f:
             json.dump(data, f)
 
         try:
             with self.assertRaises(SystemExit) as cm:
                 with capture(main) as (out, err, ret):
-                    self.assertIn('ERROR', err)
-                    self.assertIn('missing entries: cue_out', err)
+                    self.assertIn("ERROR", err)
+                    self.assertIn("missing entries: cue_out", err)
             self.assertEqual(cm.exception.code, 1)
         finally:
             sys.arv = argv
 
     def testIndexTooManyEntries(self):
         from klangbecken import main
-        argv, sys.argv = sys.argv, ['', 'fsck', '-d', self.tempdir]
 
-        index_path = os.path.join(self.tempdir, 'index.json')
+        argv, sys.argv = sys.argv, ["", "fsck", "-d", self.tempdir]
+
+        index_path = os.path.join(self.tempdir, "index.json")
         with open(index_path) as f:
             data = json.load(f)
 
         entry = next(iter(data.values()))
-        entry['whatever'] = 'whatever'
+        entry["whatever"] = "whatever"
 
-        with open(index_path, 'w') as f:
+        with open(index_path, "w") as f:
             json.dump(data, f)
 
         try:
             with self.assertRaises(SystemExit) as cm:
                 with capture(main) as (out, err, ret):
-                    self.assertIn('ERROR', err)
-                    self.assertIn('too many entries: whatever', err)
+                    self.assertIn("ERROR", err)
+                    self.assertIn("too many entries: whatever", err)
             self.assertEqual(cm.exception.code, 1)
         finally:
             sys.arv = argv
 
     def testIndexMissingFile(self):
         from klangbecken import main
-        argv, sys.argv = sys.argv, ['', 'fsck', '-d', self.tempdir]
 
-        os.remove(os.path.join(self.jingles_dir,
-                               os.listdir(self.jingles_dir)[0]))
+        argv, sys.argv = sys.argv, ["", "fsck", "-d", self.tempdir]
+
+        os.remove(os.path.join(self.jingles_dir, os.listdir(self.jingles_dir)[0]))
 
         try:
             with self.assertRaises(SystemExit) as cm:
                 with capture(main) as (out, err, ret):
-                    self.assertIn('ERROR', err)
-                    self.assertIn('file does not exist', err)
+                    self.assertIn("ERROR", err)
+                    self.assertIn("file does not exist", err)
             self.assertEqual(cm.exception.code, 1)
         finally:
             sys.arv = argv
 
     def testTagsValueMismatch(self):
         from klangbecken import main, SUPPORTED_FILE_TYPES
-        argv, sys.argv = sys.argv, ['', 'fsck', '-d', self.tempdir]
 
-        file_path = os.path.join(self.jingles_dir,
-                                 os.listdir(self.jingles_dir)[0])
-        FileType = SUPPORTED_FILE_TYPES['.' + file_path.split('.')[-1]]
+        argv, sys.argv = sys.argv, ["", "fsck", "-d", self.tempdir]
+
+        file_path = os.path.join(self.jingles_dir, os.listdir(self.jingles_dir)[0])
+        FileType = SUPPORTED_FILE_TYPES["." + file_path.split(".")[-1]]
         mutagenfile = FileType(file_path)
-        mutagenfile['artist'] = 'Whatever'
+        mutagenfile["artist"] = "Whatever"
         mutagenfile.save()
 
         try:
             with self.assertRaises(SystemExit) as cm:
                 with capture(main) as (out, err, ret):
-                    self.assertIn('ERROR', err)
+                    self.assertIn("ERROR", err)
                     self.assertIn("Tag value mismatch 'artist'", err)
             self.assertEqual(cm.exception.code, 1)
         finally:
@@ -259,54 +267,57 @@ class FsckTestCase(unittest.TestCase):
 
     def testPlaylistWeightMismatch(self):
         from klangbecken import main
-        argv, sys.argv = sys.argv, ['', 'fsck', '-d', self.tempdir]
 
-        playlist_path = os.path.join(self.tempdir, 'jingles.m3u')
+        argv, sys.argv = sys.argv, ["", "fsck", "-d", self.tempdir]
+
+        playlist_path = os.path.join(self.tempdir, "jingles.m3u")
         with open(playlist_path) as f:
             lines = f.readlines()
-        with open(playlist_path, 'w') as f:
-            f.writelines(lines[::2])    # only write back every second line
+        with open(playlist_path, "w") as f:
+            f.writelines(lines[::2])  # only write back every second line
 
         try:
             with self.assertRaises(SystemExit) as cm:
                 with capture(main) as (out, err, ret):
-                    self.assertIn('ERROR', err)
-                    self.assertIn('Playlist weight mismatch', err)
+                    self.assertIn("ERROR", err)
+                    self.assertIn("Playlist weight mismatch", err)
             self.assertEqual(cm.exception.code, 1)
         finally:
             sys.arv = argv
 
     def testDanglingPlaylistEntries(self):
         from klangbecken import main
-        argv, sys.argv = sys.argv, ['', 'fsck', '-d', self.tempdir]
 
-        playlist_path = os.path.join(self.tempdir, 'jingles.m3u')
-        with open(playlist_path, 'a') as f:
-            f.write('jingles/not_an_uuid.mp3\n')
+        argv, sys.argv = sys.argv, ["", "fsck", "-d", self.tempdir]
+
+        playlist_path = os.path.join(self.tempdir, "jingles.m3u")
+        with open(playlist_path, "a") as f:
+            f.write("jingles/not_an_uuid.mp3\n")
 
         try:
             with self.assertRaises(SystemExit) as cm:
                 with capture(main) as (out, err, ret):
-                    self.assertIn('ERROR', err)
-                    self.assertIn('Dangling playlist entry', err)
-                    self.assertIn('not_an_uuid', err)
+                    self.assertIn("ERROR", err)
+                    self.assertIn("Dangling playlist entry", err)
+                    self.assertIn("not_an_uuid", err)
             self.assertEqual(cm.exception.code, 1)
         finally:
             sys.arv = argv
 
     def testDanglingFiles(self):
         from klangbecken import main
-        argv, sys.argv = sys.argv, ['', 'fsck', '-d', self.tempdir]
 
-        with open(os.path.join(self.tempdir, 'jingles', 'not_an_uuid'), 'w'):
+        argv, sys.argv = sys.argv, ["", "fsck", "-d", self.tempdir]
+
+        with open(os.path.join(self.tempdir, "jingles", "not_an_uuid"), "w"):
             pass
 
         try:
             with self.assertRaises(SystemExit) as cm:
                 with capture(main) as (out, err, ret):
-                    self.assertIn('ERROR', err)
-                    self.assertIn('Dangling files', err)
-                    self.assertIn('not_an_uuid', err)
+                    self.assertIn("ERROR", err)
+                    self.assertIn("Dangling files", err)
+                    self.assertIn("not_an_uuid", err)
             self.assertEqual(cm.exception.code, 1)
         finally:
             sys.arv = argv

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,10 +1,11 @@
 import datetime
 import json
-import mock
 import os
 import shutil
 import tempfile
 import unittest
+
+import mock
 
 from .utils import capture
 
@@ -12,10 +13,11 @@ from .utils import capture
 class ImporterTestCase(unittest.TestCase):
     def setUp(self):
         from klangbecken import _check_data_dir
+
         self.current_path = os.path.dirname(os.path.realpath(__file__))
         self.tempdir = tempfile.mkdtemp()
-        self.music_dir = os.path.join(self.tempdir, 'music')
-        self.jingles_dir = os.path.join(self.tempdir, 'jingles')
+        self.music_dir = os.path.join(self.tempdir, "music")
+        self.jingles_dir = os.path.join(self.tempdir, "jingles")
         _check_data_dir(self.tempdir, create=True)
 
     def tearDown(self):
@@ -25,119 +27,121 @@ class ImporterTestCase(unittest.TestCase):
         from klangbecken import import_cmd
         import dateutil.parser
 
-        audio_path = os.path.join(self.current_path, 'audio')
-        audio1_path = os.path.join(audio_path, 'silence.mp3')
-        audio2_path = os.path.join(audio_path, 'padded.ogg')
-        audio1_mtime = datetime.datetime.fromtimestamp(
-            os.stat(audio1_path).st_mtime
-        )
+        audio_path = os.path.join(self.current_path, "audio")
+        audio1_path = os.path.join(audio_path, "silence.mp3")
+        audio2_path = os.path.join(audio_path, "padded.ogg")
+        audio1_mtime = datetime.datetime.fromtimestamp(os.stat(audio1_path).st_mtime)
 
         # Import nothing -> usage
-        args = [self.tempdir, 'music', [], True]
+        args = [self.tempdir, "music", [], True]
         with self.assertRaises(SystemExit) as cm:
             with capture(import_cmd, *args) as (out, err, ret):
                 pass
 
         # Import one file
-        args = [self.tempdir, 'music', [audio1_path], True]
+        args = [self.tempdir, "music", [audio1_path], True]
         with self.assertRaises(SystemExit) as cm:
             with capture(import_cmd, *args) as (out, err, ret):
-                self.assertIn('Successfully imported 1 of 1 files.', out)
+                self.assertIn("Successfully imported 1 of 1 files.", out)
         self.assertEqual(cm.exception.code, 0)
 
-        files = [f for f in os.listdir(self.music_dir)
-                 if os.path.isfile(os.path.join(self.music_dir, f))]
+        files = [
+            f
+            for f in os.listdir(self.music_dir)
+            if os.path.isfile(os.path.join(self.music_dir, f))
+        ]
         self.assertEqual(len(files), 1)
-        with open(os.path.join(self.tempdir, 'index.json')) as file:
+        with open(os.path.join(self.tempdir, "index.json")) as file:
             data = json.load(file)
             self.assertEqual(len(data.keys()), 1)
-            ts = list(data.values())[0]['import_timestamp']
+            ts = list(data.values())[0]["import_timestamp"]
             ts = dateutil.parser.parse(ts)
-            self.assertTrue(abs(ts - audio1_mtime)
-                            < datetime.timedelta(seconds=1))
-            self.assertEqual(list(data.values())[0]['original_filename'],
-                             'silence.mp3')
+            self.assertTrue(abs(ts - audio1_mtime) < datetime.timedelta(seconds=1))
+            self.assertEqual(list(data.values())[0]["original_filename"], "silence.mp3")
 
         # Import two file
-        args = [self.tempdir, 'music', [audio1_path, audio2_path], True]
+        args = [self.tempdir, "music", [audio1_path, audio2_path], True]
         with self.assertRaises(SystemExit) as cm:
             with capture(import_cmd, *args) as (out, err, ret):
-                self.assertIn('Successfully imported 2 of 2 files.', out)
+                self.assertIn("Successfully imported 2 of 2 files.", out)
         self.assertEqual(cm.exception.code, 0)
 
-        files = [f for f in os.listdir(self.music_dir)  # pragma: no cover
-                 if os.path.isfile(os.path.join(self.music_dir, f))]
+        files = [
+            f
+            for f in os.listdir(self.music_dir)  # pragma: no cover
+            if os.path.isfile(os.path.join(self.music_dir, f))
+        ]
         self.assertEqual(len(files), 3)
-        with open(os.path.join(self.tempdir, 'index.json')) as file:
+        with open(os.path.join(self.tempdir, "index.json")) as file:
             self.assertEqual(len(json.load(file).keys()), 3)
 
         # Try importing inexistent file
-        args = [self.tempdir, 'music', [audio1_path, 'inexistent'], True]
+        args = [self.tempdir, "music", [audio1_path, "inexistent"], True]
         with self.assertRaises(SystemExit) as cm:
             with capture(import_cmd, *args) as (out, err, ret):
-                self.assertIn('Successfully imported 1 of 2 files.', out)
-                self.assertIn('WARNING', err)
+                self.assertIn("Successfully imported 1 of 2 files.", out)
+                self.assertIn("WARNING", err)
         self.assertEqual(cm.exception.code, 1)
 
         # Try importing into inexistent playlist
-        args = [self.tempdir, 'nonexistent', [audio1_path], True]
+        args = [self.tempdir, "nonexistent", [audio1_path], True]
         with self.assertRaises(SystemExit) as cm:
             with capture(import_cmd, *args) as (out, err, ret):
-                self.assertEqual(out.strip(), '')
-                self.assertIn('ERROR', err)
+                self.assertEqual(out.strip(), "")
+                self.assertIn("ERROR", err)
         self.assertEqual(cm.exception.code, 1)
 
         # Try importing into inexistent data dir
-        args = [self.tempdir, 'inexistent', [audio1_path], True]
+        args = [self.tempdir, "inexistent", [audio1_path], True]
         with self.assertRaises(SystemExit) as cm:
             with capture(import_cmd, *args) as (out, err, ret):
-                self.assertEqual(out.strip(), '')
-                self.assertIn('ERROR', err)
+                self.assertEqual(out.strip(), "")
+                self.assertIn("ERROR", err)
         self.assertEqual(cm.exception.code, 1)
 
-        path = os.path.join(self.tempdir, 'file.wmv')
-        with open(path, 'w'):
+        path = os.path.join(self.tempdir, "file.wmv")
+        with open(path, "w"):
             pass
 
         # Try importing unsupported file type
-        args = [self.tempdir, 'music', [path], True]
+        args = [self.tempdir, "music", [path], True]
         with self.assertRaises(SystemExit) as cm:
             with capture(import_cmd, *args) as (out, err, ret):
-                self.assertIn('Successfully imported 0 of 1 files.', out)
-                self.assertIn('WARNING', err)
+                self.assertIn("Successfully imported 0 of 1 files.", out)
+                self.assertIn("WARNING", err)
         self.assertEqual(cm.exception.code, 1)
 
-    @mock.patch('klangbecken.input', return_value='y')
+    @mock.patch("klangbecken.input", return_value="y")
     def testImportInteractiveYes(self, input):
         from klangbecken import import_cmd
 
-        audio_path = os.path.join(self.current_path, 'audio')
-        audio1_path = os.path.join(audio_path, 'silence.mp3')
+        audio_path = os.path.join(self.current_path, "audio")
+        audio1_path = os.path.join(audio_path, "silence.mp3")
 
-        args = [self.tempdir, 'music', [audio1_path], False]
+        args = [self.tempdir, "music", [audio1_path], False]
         with self.assertRaises(SystemExit) as cm:
             with capture(import_cmd, *args) as (out, err, ret):
-                self.assertIn('Successfully analyzed 1 of 1 files.', out)
-                self.assertIn('Successfully imported 1 of 1 files.', out)
-                music_dir = os.path.join(self.tempdir, 'music')
+                self.assertIn("Successfully analyzed 1 of 1 files.", out)
+                self.assertIn("Successfully imported 1 of 1 files.", out)
+                music_dir = os.path.join(self.tempdir, "music")
                 file_count = len(os.listdir(music_dir))
                 self.assertEqual(file_count, 1)
         self.assertEqual(cm.exception.code, 0)
 
-    @mock.patch('klangbecken.input', return_value='n')
+    @mock.patch("klangbecken.input", return_value="n")
     def testImportInteractiveNo(self, input):
         from klangbecken import import_cmd
 
-        audio_path = os.path.join(self.current_path, 'audio')
-        audio1_path = os.path.join(audio_path, 'silence.mp3')
+        audio_path = os.path.join(self.current_path, "audio")
+        audio1_path = os.path.join(audio_path, "silence.mp3")
 
-        args = [self.tempdir, 'music', [audio1_path], False]
+        args = [self.tempdir, "music", [audio1_path], False]
 
         with self.assertRaises(SystemExit) as cm:
             with capture(import_cmd, *args) as (out, err, ret):
-                self.assertIn('Successfully analyzed 1 of 1 files.', out)
-                self.assertIn('Successfully imported 0 of 1 files.', out)
-                music_dir = os.path.join(self.tempdir, 'music')
+                self.assertIn("Successfully analyzed 1 of 1 files.", out)
+                self.assertIn("Successfully imported 0 of 1 files.", out)
+                music_dir = os.path.join(self.tempdir, "music")
                 file_count = len(os.listdir(music_dir))
                 self.assertEqual(file_count, 0)
         self.assertEqual(cm.exception.code, 1)


### PR DESCRIPTION
This PR reformats the code using [black](https://black.readthedocs.io/en/stable/), configures isort & flake8 to match and adds [pre-commit](https://pre-commit.com/) to the README as well as to the travis tests. I also took care of fixing or ignoring any issues found by flake8.

My apologies for the huge changeset, all of this does not touch/refactor any of the business logic ~~or logic in setup.py~~ (it touches how requirements are read from txt files in setup.py)... The changes to .travis.yml are kept as minimal as possible.

I plan on taking care of the werkzeug deprecation warnings in a future pull request and this prepares the repo to make it easy to do so. I'll also automate dependency bumping PRs once this is merged.