### PR TITLE
:loud_sound: (liquidsoap) log to stdout instead of a file

### DIFF
--- a/klangbecken.liq
+++ b/klangbecken.liq
@@ -2,9 +2,8 @@
 # SETTINGS                                          #
 # ================================================= #
 
-set("log.file", true)
-set("log.file.path","<syslogdir>/<script>.log")
-set("log.stdout", false)
+set("log.file", false)
+set("log.stdout", true)
 set("server.telnet", false)
 set("server.telnet.port", 1234)
 set("log.level", 3)


### PR DESCRIPTION
By logging to stdout instead of a file we use systemd-journald to store logs and we stop loosing
logs due to liquidsoap restarts.