### PR TITLE
WIP: Stop sniffing mimetype on playlists and don't use playlist.once anymore

### DIFF
--- a/klangbecken.liq
+++ b/klangbecken.liq
@@ -100,24 +100,24 @@ def check_next_func(r) =
 end
 
 # Priority playlist for 'play next' feature
-prio = playlist.once(id="prio", reload_mode="watch", path.concat(DATA_DIR, "prio.m3u"))
+prio = playlist(id="prio", reload_mode="watch", mode="normal", mime_type="audio/x-mpegurl", path.concat(DATA_DIR, "prio.m3u"))
 # Cut silence at start and end
 prio = cue_cut(prio, cue_in_metadata="cue_in", cue_out_metadata="cue_out")
 
 # Music playlist
-music = playlist(id="music", mode="random", reload_mode="watch",
+music = playlist(id="music", mode="random", reload_mode="watch", mime_type="audio/x-mpegurl",
                  check_next=check_next_func, path.concat(DATA_DIR, "music.m3u"))
 # Cut silence at start and end
 music = cue_cut(music, cue_in_metadata="cue_in", cue_out_metadata="cue_out")
 
 # Classics playlist
-classics = playlist(id="classics", mode="random", reload_mode="watch",
+classics = playlist(id="classics", mode="random", reload_mode="watch", mime_type="audio/x-mpegurl",
                     check_next=check_next_func, path.concat(DATA_DIR, "classics.m3u"))
 # Cut silence at start and end
 classics = cue_cut(classics, cue_in_metadata="cue_in", cue_out_metadata="cue_out")
 
 # Jingles playlist
-jingles = playlist(id="jingles", mode="random", reload_mode="watch",
+jingles = playlist(id="jingles", mode="random", reload_mode="watch", mime_type="audio/x-mpegurl",
                    check_next=check_next_func, path.concat(DATA_DIR, "jingles.m3u"))
 # Convert mono jingles to stereo
 jingles = audio_to_stereo(jingles)


### PR DESCRIPTION
This replaces the mime type sniffing that we are doing when loading a playlist with a hardcoded mime type. We can always assume that the generated m3u files have a `text/plain` mime type. With this assumption liquidsoap won't log `Wrong mime type application/octet-stream for playlist!` if the file is empty.

We need to switch to not using `playlist.once` anymore since it is deprecated nowadays: https://github.com/savonet/liquidsoap/pull/1015. I think we don't need to use `reload_mode="once"` but can stick to `reload_mode=watch` since the prio file is handled in a way that watching it leads to the behaviour we want.

* [x] deactivate mime type sniffing
* [x] refactor so we don't use `playlist.once anymore`
* [ ] test if this works with all the liquidsoap versions we are supporting (currently 1.3.2 with the possibilty to upgrade to 1.3.7 which has already been built, 1.4 support depends on us rolling out CentOS 8)