### PR TITLE
Travis: support multiple versions of liquidsoap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 dist: bionic
 language: python
 python:
@@ -25,19 +26,32 @@ script:
   - flake8
 after_success:
   - codecov
-matrix:
+
+# define liquidsoap anchor
+_liquidsoap: &liquidsoap
+  language: shell
+  services: docker
+  addons: 
+    apt:
+      packages:
+  before_install: skip
+  install: skip
+  before_script:
+    - docker pull radiorabe/liquidsoap:alpine-$LS_VERSION
+  script:
+    - docker run --rm -ti radiorabe/liquidsoap:alpine-$LS_VERSION --version
+    - mkdir $KLANGBECKEN_DATA
+    - touch $KLANGBECKEN_DATA/prio.m3u $KLANGBECKEN_DATA/music.m3u $KLANGBECKEN_DATA/classics.m3u $KLANGBECKEN_DATA/jingles.m3u $KLANGBECKEN_DATA/index.json
+    - docker run --rm -ti -e KLANGBECKEN_DATA=$KLANGBECKEN_DATA -v $KLANGBECKEN_DATA:$KLANGBECKEN_DATA -v `pwd`:/var/lib/liquidsoap radiorabe/liquidsoap:alpine-$LS_VERSION --check /var/lib/liquidsoap/klangbecken.liq
+  after_script: skip
+  after_success: skip
+  after_failure: skip
+
+jobs:
   include:
-    - language: minimal
-      services:
-        - docker
-      addons:
-        apt:
-          packages:
-      before_install:
-      install:
-      script:
-        - docker run --rm -ti radiorabe/liquidsoap --version
-        - mkdir $KLANGBECKEN_DATA
-        - touch $KLANGBECKEN_DATA/prio.m3u $KLANGBECKEN_DATA/music.m3u $KLANGBECKEN_DATA/classics.m3u $KLANGBECKEN_DATA/jingles.m3u $KLANGBECKEN_DATA/index.json
-        - docker run --rm -ti -e KLANGBECKEN_DATA=$KLANGBECKEN_DATA -v $KLANGBECKEN_DATA:$KLANGBECKEN_DATA -v `pwd`:/var/lib/liquidsoap radiorabe/liquidsoap --check klangbecken.liq
-      after_success:
+    - <<: *liquidsoap
+      name: Liquidsoap 1.3.2
+      env: LS_VERSION=1.3.2
+    - <<: *liquidsoap
+      name: Liquidsoap 1.3.7
+      env: LS_VERSION=1.3.7


### PR DESCRIPTION
This enables us to test multiple versions of Liquidsoap using Travis. Once we migrated to 4.x we can also move to `radiorabe/liquidsoap:alpine-1.4.x`.