### PR TITLE
refactor: get rid of dot prefix for file type (extension)

### DIFF
--- a/tests/test_devserver.py
+++ b/tests/test_devserver.py
@@ -99,7 +99,7 @@ class StandaloneWebApplicationTestCase(unittest.TestCase):
             "album": "☀⚛♬",
             "title": "ÄÖÜ",
             "artist": "ÀÉÈ",
-            "ext": ".mp3",
+            "ext": "mp3",
             "weight": 1,
             "playlist": "music",
             "id": fileId,

--- a/tests/test_fsck.py
+++ b/tests/test_fsck.py
@@ -251,7 +251,7 @@ class FsckTestCase(unittest.TestCase):
         argv, sys.argv = sys.argv, ["", "fsck", "-d", self.tempdir]
 
         file_path = os.path.join(self.jingles_dir, os.listdir(self.jingles_dir)[0])
-        FileType = SUPPORTED_FILE_TYPES["." + file_path.split(".")[-1]]
+        FileType = SUPPORTED_FILE_TYPES[file_path.split(".")[-1]]
         mutagenfile = FileType(file_path)
         mutagenfile["artist"] = "Whatever"
         mutagenfile.save()


### PR DESCRIPTION
This should only be merged after merging https://github.com/radiorabe/klangbecken-ui/pull/114