### PR TITLE
WIP: Rework priority queue and liquidsoap player interaction

### DIFF
--- a/klangbecken.liq
+++ b/klangbecken.liq
@@ -104,8 +104,10 @@ def check_next_func(r) =
   end
 end
 
-# Priority playlist for 'play next' feature
-prio = playlist.once(id="prio", reload_mode="watch", path.concat(DATA_DIR, "prio.m3u"))
+# Priority queue
+prio = request.equeue(id="queue", length=5.0)
+# Convert mono jingles to stereo
+prio = audio_to_stereo(prio)
 # Cut silence at start and end
 prio = cue_cut(prio, cue_in_metadata="cue_in", cue_out_metadata="cue_out")
 
@@ -138,13 +140,6 @@ music = random(weights=[5, 1], [music, classics])
 
 
 # ================================================= #
-# PLAY FROM PRIORITY PLAYLIST IF AVAILABLE          #
-# ================================================= #
-
-music = fallback([prio, music])
-
-
-# ================================================= #
 # INSERT JINGLE EVERY 15 MINUTES                    #
 # ================================================= #
 
@@ -169,11 +164,15 @@ radio = switch(id="radio", [
 def on_track_func(m) =
   # Reset jingle playing flag
   insert_jingle := false
-
-  # Clear prio playlist
-  system("echo > #{DATA_DIR}/prio.m3u")
 end
 radio = on_track(on_track_func, radio)
+
+
+# ============================================== #
+# PLAY FROM PRIORITY QUEUE IF AVAILABLE          #
+# ============================================== #
+
+radio = fallback([prio, radio])
 
 
 # ================================================= #

--- a/klangbecken.liq
+++ b/klangbecken.liq
@@ -37,7 +37,7 @@ set("log.level", 3)
 
 # socket
 set("server.socket", true)
-set_if_env("server.socket.path", "KLANGBECKEN_SOCKET_PATH")
+set("server.socket.path", getenv_fallback("KLANGBECKEN_SOCKET_PATH", "./klangbecken.sock"))
 
 # Get the Klangbecken data directory
 DATA_DIR = getenv_fallback("KLANGBECKEN_DATA", "data")

--- a/klangbecken.liq
+++ b/klangbecken.liq
@@ -183,22 +183,32 @@ restart = ref true
 onair = ref false
 
 def onair_func(state) =
-  onair := bool_of_string(string.case(state))
-  if !onair then
+  state = string.case(state)
+  state = string.trim(state)
+  if state == "true" then
+    onair := true
     log("Starting Klangbecken")
     restart := true
     source.skip(radio)
     "Klangbecken started"
-  else
+  elsif state == "false" then
+    onair := false
     log("Stopping Klangbecken")
     system("#{CMD_PATH} playlog -d #{DATA_DIR} --off")
     "Klangbecken stopped"
+  elsif state != "" then
+    msg = "ERROR: Cannot set new 'onair' state: #{state}"
+    log(msg)
+    msg
+  else
+    # Return state
+    "#{!onair}"
   end
 end
 
 server.register(namespace='klangbecken',
-                description="Control, if the player is on air",
-                usage="onair (true|false)",
+                description="Control, if the player is on air. Returns the current state, if called without argument.",
+                usage="onair [true|false]",
                 "onair",
                 onair_func)
 

--- a/klangbecken.py
+++ b/klangbecken.py
@@ -660,16 +660,17 @@ class KlangbeckenAPI:
             # Authentication
             (("GET", "POST"), "/auth/login/", "auth_login"),
             ("POST", "/auth/renew/", "auth_renew"),
-            # Playlist management
+            # Playlist
             ("POST", "/playlist/" + playlist_url, "playlist_upload",),
             ("PUT", "/playlist/" + file_url, "playlist_update"),
             ("DELETE", "/playlist/" + file_url, "playlist_delete"),
-            # Player interaction
+            # Player
             ("GET", "/player/", "player_info"),
-            ("POST", "/player/", "player_queue_push"),
-            ("PUT", "/player/<int:rid>", "player_queue_move"),
-            ("DELETE", "/player/<int:rid>", "player_queue_delete",),
-            ("DELETE", "/player/", "player_queue_clear"),
+            # Queue
+            ("POST", "/player/queue/", "queue_push"),
+            ("PUT", "/player/queue/<rid>", "queue_move"),
+            ("DELETE", "/player/queue/<rid>", "queue_delete",),
+            ("DELETE", "/player/queue/", "queue_clear"),
         )
 
         self.url_map = Map(

--- a/klangbecken.py
+++ b/klangbecken.py
@@ -566,8 +566,6 @@ class LiquidsoapClient:
         for rid in self.command("queue.secondary_queue").strip().split():
             self.delete(rid)
 
-    # def move(self, rid, pos):
-    #     raise NotImplemented
 
 def _fix_filename(fname, playlist=r"(?:{})".format("|".join(PLAYLISTS))):
     # FIXME: Correctly match file types
@@ -896,18 +894,6 @@ class JSONResponse(Response):
         super(JSONResponse, self).__init__(
             json.dumps(data, **json_opts), status=status, mimetype="text/json"
         )
-
-
-class JSONSerializer:
-    @staticmethod
-    def dumps(obj):
-        # UTF-8 encoding is default in Python 3+
-        return json.dumps(obj).encode("utf-8")
-
-    @staticmethod
-    def loads(serialized):
-        # UTF-8 encoding is default in Python 3+
-        return json.loads(str(serialized, "utf-8"))
 
 
 ###########################

--- a/klangbecken.py
+++ b/klangbecken.py
@@ -548,7 +548,7 @@ class LiquidsoapClient:
         if queue.index(rid) != pos:
             if pos == (len(queue) - 1):
                 pos = -1
-            ans = self.tel.command(f"queue.move {rid} {pos}")
+            ans = self.command(f"queue.move {rid} {pos}")
             if ans.strip() != "OK":
                 raise "Internal Error, should not happen"
 

--- a/klangbecken.py
+++ b/klangbecken.py
@@ -730,7 +730,11 @@ class KlangbeckenAPI:
             endpoint, values = adapter.match()
 
             # Check authorization
-            if self.do_auth and endpoint not in ("login", "renew"):
+            if self.do_auth and endpoint not in (
+                "auth_login",
+                "auth_renew",
+                "player_info",
+            ):
                 if "Authorization" not in request.headers:
                     raise Unauthorized("No authorization header supplied")
 

--- a/klangbecken.py
+++ b/klangbecken.py
@@ -983,6 +983,7 @@ def serve_cmd(
     address="localhost",
     port=5000,
     player_socket="./klangbecken.sock",
+    *,
     dev_mode=False,
 ):
     # Run locally in stand-alone development mode
@@ -996,7 +997,7 @@ def serve_cmd(
 
 
 def import_cmd(  # noqa: C901
-    data_dir, playlist, files, yes, meta=None, use_mtime=True, dev_mode=False
+    data_dir, playlist, files, yes, meta=None, use_mtime=True, *, dev_mode=False
 ):
     """Entry point for import script."""
 
@@ -1059,7 +1060,7 @@ def import_cmd(  # noqa: C901
     sys.exit(1 if count < len(files) else 0)
 
 
-def fsck_cmd(data_dir, repair=False, dev_mode=False):  # noqa: C901
+def fsck_cmd(data_dir, repair=False, *, dev_mode=False):  # noqa: C901
     """Entry point for fsck script."""
 
     song_id = None
@@ -1172,7 +1173,7 @@ def fsck_cmd(data_dir, repair=False, dev_mode=False):  # noqa: C901
     sys.exit(1 if err.count else 0)
 
 
-def playlog_cmd(data_dir, filename, off_air=False, dev_mode=False):
+def playlog_cmd(data_dir, filename, off_air=False, *, dev_mode=False):
     if off_air:
         with open(os.path.join(data_dir, "log", "current.json"), "w") as f:
             json.dump(False, f)
@@ -1220,7 +1221,7 @@ def playlog_cmd(data_dir, filename, off_air=False, dev_mode=False):
 EXTERNAL_PLAY_LOGGER = os.environ.get("KLANGBECKEN_EXTERNAL_PLAY_LOGGER", "")
 
 
-def reanalyze_cmd(data_dir, ids, all=False, yes=False, dev_mode=False):
+def reanalyze_cmd(data_dir, ids, all=False, yes=False, *, dev_mode=False):
     with locked_open(os.path.join(data_dir, "index.json")) as f:
         data = json.load(f)
     if all:

--- a/klangbecken.py
+++ b/klangbecken.py
@@ -466,7 +466,7 @@ class LiquidsoapClient:
         ans = re.sub(b"[\r\n]*END$", b"", ans)
         ans = re.sub(b"^[\r\n]*", b"", ans)
         ans = re.subn(b"[\r\n]", b"\n", ans)[0]
-        return ans.decode("ascii", "ignore")
+        return ans.decode("ascii", "ignore").strip()
 
     def metadata(self, rid):
         ans = self.command(f"request.metadata {rid}")


### PR DESCRIPTION
**Warning**: This code is still in a very preliminary stage... :worried: 

This PR should clarify some parts of the system, and also introduce the feature of a arbitrarily long and editable 'play next' queue.

As for now, some files on the file system hold long-lived information like the playlist and audio files. But some information is only short-lived. This includes the `current.json` for the currently played song, or the `prio.m3u` priority playlist.

With this PR we clarify the situation. The file system only holds long-living information:
 - Audio files
 - Playlist files (`*.m3u`)
 - Logs (`*.csv`)
 - The `index.json` cache

All the short-lived information about the current state of the player is retrieved directly from the liquidsoap process via it's telnet interface with the `LiquidsoapClient`. This includes:
 - Current song with it's remaining time
 - Next songs queued in the playlists
 - Additional meta information like uptime and version

Additionally this PR replaces the `prio.m3u` with a new queue using liquidsoap's [`request.equeue`](https://www.liquidsoap.info/doc-1.4.2/reference.html#request.equeue), supporting queue editing (reordering and deleting).

- [ ] Prioritize queue or jingles?
- [ ] Unit testing
- [x] Simplify JSON validation in `KlangbeckenAPI`
- [ ] UI

Fixes #29 