### PR TITLE
Fix `fsck` command: account for track logging while fsck happens

### DIFF
--- a/test/test_cli_fsck.py
+++ b/test/test_cli_fsck.py
@@ -64,7 +64,7 @@ class FsckTestCase(unittest.TestCase):
         finally:
             sys.arv = argv
 
-    def testFsck(self):
+    def testFsckInexistentDataDir(self):
         from klangbecken.cli import main
 
         argv, sys.argv = sys.argv, ["", "fsck", "-d", "invalid"]
@@ -75,9 +75,14 @@ class FsckTestCase(unittest.TestCase):
                     self.assertIn("ERROR", err)
                     self.assertIn("Data directory 'invalid' does not exist", err)
             self.assertEqual(cm.exception.code, 1)
+        finally:
+            sys.arv = argv
 
-            sys.argv[-1] = self.tempdir
+    def testFsck(self):
+        from klangbecken.cli import main
 
+        argv, sys.argv = sys.argv, ["", "fsck", "-d", self.tempdir]
+        try:
             # correct invocation
             with self.assertRaises(SystemExit) as cm:
                 with capture(main) as (out, err, ret):


### PR DESCRIPTION
Running fsck usually takes a little while (up to half a minute with cold fs caches). During this time a track or two might be played, and the `last_play` date is logged in the audio file under the `last_play` tag. The index cache file is read entirely at the beginning, but the audio file tags are read track after track. The `fsck` command thus might wrongly report a data inconsistency.

This PR prevents `fsck` from reporting (exactly) these kind of inconsistencies.