### PR TITLE
chore: remove secondary Flake8 deps

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,3 @@
 -r requirements.txt
 coverage==6.3.2
 flake8==4.0.1
-
-# secondary dependencies (flake8)
-mccabe==0.6.1
-pycodestyle==2.8.0
-pyflakes==2.4.0


### PR DESCRIPTION
The Flake8 deps are already narrowly pinned in flake8.

The Flake8 core team has [this to say](https://flake8.pycqa.org/en/latest/faq.html#should-i-file-an-issue-when-a-new-version-of-a-dependency-is-available):

> Should I file an issue when a new version of a dependency is available?
No. The current Flake8 core team (of one person) is also a core developer of pycodestyle, pyflakes, and mccabe. They are aware of these releases.

The deps don't release any bc breaking things in the ranges pinned by upstream (semver style).

Removing them teaches dependabot not to do stuff like #131. This way  dependabot creates just one flake8 pr that is helpful instead of what is currently happening.