### PR TITLE
fix(cli): reload jingles playlist in liquidsoap after expiring

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         sudo add-apt-repository ppa:deadsnakes/ppa
         sudo apt-get update
-        sudo apt-get install python3.7 python3.7-distutils python3.9 python3.9-distutils python3.10 python3.10-distutils
+        sudo apt-get install python3.7 python3.7-distutils python3.9 python3.9-distutils python3.10 python3.10-distutils python3.11
 
     - name: Install ffmpeg
       run: sudo apt-get install ffmpeg

--- a/doc/systemd/klangbecken-disable-expired.timer
+++ b/doc/systemd/klangbecken-disable-expired.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=Run klangbecken-disable-expired.service hourly
+Description=Run klangbecken-disable-expired.service daily
 
 [Timer]
 OnCalendar=*-*-* *:05:00

--- a/doc/systemd/klangbecken-reload-jingles.service
+++ b/doc/systemd/klangbecken-reload-jingles.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Reload Jingles playlist after expire to workaround missing inotify support
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/klangbecken.conf
+ExecStart=/bin/bash -c 'echo "jingles.reload" | nc -U ${KLANGBECKEN_PLAYER_SOCKET}'
+User=liquidsoap
+Group=liquidsoap
+
+[Install]
+WantedBy=multi-user.target

--- a/doc/systemd/klangbecken-reload-jingles.timer
+++ b/doc/systemd/klangbecken-reload-jingles.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Run klangbecken-reload-jingles.service daily
+
+[Timer]
+OnCalendar=*-*-* *:05:30
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
I solved our jingles not expiring problem in liquidsoap the dirty way. I do hope that liquidsoap +1.3.7 handles inotify better.